### PR TITLE
Local shared subscriber's routing cache

### DIFF
--- a/apps/vmq_commons/src/packet.erl
+++ b/apps/vmq_commons/src/packet.erl
@@ -4,6 +4,10 @@
     expect_packet/3,
     expect_packet/4,
     expect_packet/5,
+    receive_frame/1,
+    receive_frame/3,
+    receive_frame/4,
+    receive_at_most_n_frames/3,
     do_client_connect/3,
     gen_connect/2,
     gen_connack/0,
@@ -101,6 +105,54 @@ do_client_connect(ConnectPacket, ConnackPacket, Opts) ->
             end;
         ConnectError ->
             ConnectError
+    end.
+
+receive_at_most_n_frames(Socket, N, QoS) ->
+    receive_at_most_n_frames_(Socket, N, QoS, <<>>, []).
+
+receive_at_most_n_frames_(_Socket, 0, _QoS, _Rest, Acc) -> Acc;
+receive_at_most_n_frames_(Socket, N, QoS, Rest, Acc) ->
+    case receive_frame(gen_tcp, Socket, 5000, Rest) of
+        {ok, {mqtt_publish, Mid, _, _, _, _, _} = Frame, NewRest} ->
+            case QoS of
+                0 -> ok;
+                1 ->
+                    Puback = gen_puback(Mid),
+                    ok = gen_tcp:send(Socket, Puback)
+
+            end,
+            receive_at_most_n_frames_(Socket, N - 1, QoS, NewRest, [Frame | Acc]);
+        E -> io:format(user, "E: ~p", [E]), Acc
+    end.
+
+receive_frame(Socket) ->
+    receive_frame(gen_tcp, Socket).
+receive_frame(Transport, Socket) ->
+    receive_frame(Transport, Socket, 5000).
+receive_frame(Transport, Socket, Timeout) ->
+    receive_frame(Transport, Socket, Timeout, <<>>).
+
+receive_frame(Transport, Socket, Timeout, Incomplete) ->
+    case vmq_parser:parse(Incomplete) of
+        more ->
+            case Transport:recv(Socket, 0, Timeout) of
+                {ok, Data} ->
+                    NewData = <<Incomplete/binary, Data/binary>>,
+                    case vmq_parser:parse(NewData) of
+                        more ->
+                            receive_frame(Transport, Socket, Timeout, NewData);
+                        {error, R} ->
+                            {error, R};
+                        {Frame, Rest} ->
+                            {ok, Frame, Rest}
+                    end;
+                E ->
+                    E
+            end;
+        {error, R} ->
+            {error, R};
+        {Frame, Rest} ->
+            {ok, Frame, Rest}
     end.
 
 gen_connect(ClientId, Opts) ->

--- a/apps/vmq_commons/src/packet.erl
+++ b/apps/vmq_commons/src/packet.erl
@@ -110,19 +110,21 @@ do_client_connect(ConnectPacket, ConnackPacket, Opts) ->
 receive_at_most_n_frames(Socket, N, QoS) ->
     receive_at_most_n_frames_(Socket, N, QoS, <<>>, []).
 
-receive_at_most_n_frames_(_Socket, 0, _QoS, _Rest, Acc) -> Acc;
+receive_at_most_n_frames_(_Socket, 0, _QoS, _Rest, Acc) ->
+    Acc;
 receive_at_most_n_frames_(Socket, N, QoS, Rest, Acc) ->
     case receive_frame(gen_tcp, Socket, 5000, Rest) of
         {ok, {mqtt_publish, Mid, _, _, _, _, _} = Frame, NewRest} ->
             case QoS of
-                0 -> ok;
+                0 ->
+                    ok;
                 1 ->
                     Puback = gen_puback(Mid),
                     ok = gen_tcp:send(Socket, Puback)
-
             end,
             receive_at_most_n_frames_(Socket, N - 1, QoS, NewRest, [Frame | Acc]);
-        E -> io:format(user, "E: ~p", [E]), Acc
+        _E ->
+            Acc
     end.
 
 receive_frame(Socket) ->

--- a/apps/vmq_commons/src/packet.erl
+++ b/apps/vmq_commons/src/packet.erl
@@ -7,7 +7,7 @@
     receive_frame/1,
     receive_frame/3,
     receive_frame/4,
-    receive_at_most_n_frames/3,
+    receive_at_most_n_publish_frames/3,
     do_client_connect/3,
     gen_connect/2,
     gen_connack/0,
@@ -107,12 +107,12 @@ do_client_connect(ConnectPacket, ConnackPacket, Opts) ->
             ConnectError
     end.
 
-receive_at_most_n_frames(Socket, N, QoS) ->
-    receive_at_most_n_frames_(Socket, N, QoS, <<>>, []).
+receive_at_most_n_publish_frames(Socket, N, QoS) ->
+    receive_at_most_n_publish_frames_(Socket, N, QoS, <<>>, []).
 
-receive_at_most_n_frames_(_Socket, 0, _QoS, _Rest, Acc) ->
+receive_at_most_n_publish_frames_(_Socket, 0, _QoS, _Rest, Acc) ->
     Acc;
-receive_at_most_n_frames_(Socket, N, QoS, Rest, Acc) ->
+receive_at_most_n_publish_frames_(Socket, N, QoS, Rest, Acc) ->
     case receive_frame(gen_tcp, Socket, 5000, Rest) of
         {ok, {mqtt_publish, Mid, _, _, _, _, _} = Frame, NewRest} ->
             case QoS of
@@ -122,7 +122,7 @@ receive_at_most_n_frames_(Socket, N, QoS, Rest, Acc) ->
                     Puback = gen_puback(Mid),
                     ok = gen_tcp:send(Socket, Puback)
             end,
-            receive_at_most_n_frames_(Socket, N - 1, QoS, NewRest, [Frame | Acc]);
+            receive_at_most_n_publish_frames_(Socket, N - 1, QoS, NewRest, [Frame | Acc]);
         _E ->
             Acc
     end.

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -93,7 +93,12 @@
     incr_redis_cmd_miss/1,
     incr_redis_cmd_err/1,
     incr_redis_stale_cmd/1,
-    incr_unauth_redis_cmd/1
+    incr_unauth_redis_cmd/1,
+
+    incr_cache_insert/1,
+    incr_cache_delete/1,
+    incr_cache_hit/1,
+    incr_cache_miss/1
 ]).
 
 -export([
@@ -317,6 +322,18 @@ incr_unauth_redis_cmd({CMD, OPERATION}) ->
 
 incr_qos1_opts({NON_RETRY, NON_PERSISTENCE}) ->
     incr_item({?QOS1_SUBSCRIPTION_OPTS, NON_RETRY, NON_PERSISTENCE}, 1).
+
+incr_cache_insert(NAME) ->
+    incr_item({?CACHE_INSERT, NAME}, 1).
+
+incr_cache_delete(NAME) ->
+    incr_item({?CACHE_DELETE, NAME}, 1).
+
+incr_cache_hit(NAME) ->
+    incr_item({?CACHE_HIT, NAME}, 1).
+
+incr_cache_miss(NAME) ->
+    incr_item({?CACHE_MISS, NAME}, 1).
 
 incr(Entry) ->
     incr_item(Entry, 1).
@@ -1755,6 +1772,34 @@ counter_entries_def() ->
             router_matches_remote,
             router_matches_remote,
             <<"The number of matched remote subscriptions.">>
+        ),
+        m(
+            counter,
+            [{cache, rcn_to_str(?LOCAL_SHARED_SUBS)}],
+            {?CACHE_HIT, ?LOCAL_SHARED_SUBS},
+            cache_hit,
+            <<"The number of cache hit separate by cache name.">>
+        ),
+        m(
+            counter,
+            [{cache, rcn_to_str(?LOCAL_SHARED_SUBS)}],
+            {?CACHE_MISS, ?LOCAL_SHARED_SUBS},
+            cache_miss,
+            <<"The number of cache miss separate by cache name.">>
+        ),
+        m(
+            counter,
+            [{cache, rcn_to_str(?LOCAL_SHARED_SUBS)}],
+            {?CACHE_INSERT, ?LOCAL_SHARED_SUBS},
+            cache_insert,
+            <<"The number of cache insert separate by cache name.">>
+        ),
+        m(
+            counter,
+            [{cache, rcn_to_str(?LOCAL_SHARED_SUBS)}],
+            {?CACHE_DELETE, ?LOCAL_SHARED_SUBS},
+            cache_delete,
+            <<"The number of cache delete separate by cache name.">>
         )
     ].
 
@@ -2754,7 +2799,11 @@ met2idx({?QOS1_SUBSCRIPTION_OPTS, ?RETRY, ?NON_PERSISTENCE}) -> 309;
 met2idx({?QOS1_SUBSCRIPTION_OPTS, ?NON_RETRY, ?PERSISTENCE}) -> 310;
 met2idx({?QOS1_SUBSCRIPTION_OPTS, ?RETRY, ?PERSISTENCE}) -> 311;
 met2idx(?QOS1_NON_RETRY_DROPPED) -> 312;
-met2idx(?QOS1_NON_PERSISTENCE_DROPPED) -> 313.
+met2idx(?QOS1_NON_PERSISTENCE_DROPPED) -> 313;
+met2idx({?CACHE_HIT, ?LOCAL_SHARED_SUBS}) -> 314;
+met2idx({?CACHE_MISS, ?LOCAL_SHARED_SUBS}) -> 315;
+met2idx({?CACHE_INSERT, ?LOCAL_SHARED_SUBS}) -> 316;
+met2idx({?CACHE_DELETE, ?LOCAL_SHARED_SUBS}) -> 317.
 
 -ifdef(TEST).
 clear_stored_rates() ->

--- a/apps/vmq_server/src/vmq_metrics.hrl
+++ b/apps/vmq_server/src/vmq_metrics.hrl
@@ -122,6 +122,10 @@
 -define(REDIS_CMD_MISS, redis_cmd_miss).
 -define(REDIS_CMD_ERROR, redis_cmd_error).
 -define(REDIS_STALE_CMD, redis_stale_cmd).
+-define(CACHE_INSERT, cache_insert).
+-define(CACHE_DELETE, cache_delete).
+-define(CACHE_HIT, cache_hit).
+-define(CACHE_MISS, cache_miss).
 -define(UNAUTH_REDIS_CMD, unauth_redis_cmd).
 -define(METRIC_MSG_STORE_OPS_ERRORS, msg_store_ops_error).
 -define(METRIC_MSG_STORE_RETRY_EXHAUSTED, msg_store_retry_exhausted).

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -147,7 +147,7 @@ subscribe_op(vmq_reg_redis_trie, {MP, ClientId} = SubscriberId, Topics) ->
                 Key = {MP, Topic},
                 Value = {ClientId, QoS},
                 T1 = vmq_util:ts(),
-                ets:insert(vmq_shared_subs_local, {{Key, Value}}),
+                ets:insert(?SHARED_SUBS_ETS_TABLE, {{Key, Value}}),
                 vmq_metrics:pretimed_measurement(
                     {?LOCAL_SHARED_SUBS, insert},
                     vmq_util:ts() - T1
@@ -1292,7 +1292,7 @@ del_subscriber(vmq_reg_redis_trie, {MP, ClientId} = _SubscriberId) ->
     Key = {MP, '$1'},
     Value = {ClientId, '$2'},
     T1 = vmq_util:ts(),
-    ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], [true]}]),
+    ets:select_delete(?SHARED_SUBS_ETS_TABLE, [{{{Key, Value}}, [], [true]}]),
     vmq_metrics:pretimed_measurement(
         {?LOCAL_SHARED_SUBS, delete},
         vmq_util:ts() - T1
@@ -1324,7 +1324,7 @@ del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
                 Key = {MP, Topic},
                 Value = {ClientId, '$1'},
                 T1 = vmq_util:ts(),
-                ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], [true]}]),
+                ets:select_delete(?SHARED_SUBS_ETS_TABLE, [{{{Key, Value}}, [], [true]}]),
                 vmq_metrics:pretimed_measurement(
                     {?LOCAL_SHARED_SUBS, delete},
                     vmq_util:ts() - T1

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -146,12 +146,7 @@ subscribe_op(vmq_reg_redis_trie, {MP, ClientId} = SubscriberId, Topics) ->
             ({[<<"$share">>, _Group | Topic], QoS}) ->
                 Key = {MP, Topic},
                 Value = {ClientId, QoS},
-                T1 = vmq_util:ts(),
                 ets:insert(?SHARED_SUBS_ETS_TABLE, {{Key, Value}}),
-                vmq_metrics:pretimed_measurement(
-                    {?LOCAL_SHARED_SUBS, insert},
-                    vmq_util:ts() - T1
-                ),
                 vmq_metrics:incr_cache_insert(?LOCAL_SHARED_SUBS);
             (_) ->
                 ok
@@ -1291,12 +1286,7 @@ subscriptions_exist(OldSubs, Topics) ->
 del_subscriber(vmq_reg_redis_trie, {MP, ClientId} = _SubscriberId) ->
     Key = {MP, '$1'},
     Value = {ClientId, '$2'},
-    T1 = vmq_util:ts(),
     ets:select_delete(?SHARED_SUBS_ETS_TABLE, [{{{Key, Value}}, [], [true]}]),
-    vmq_metrics:pretimed_measurement(
-        {?LOCAL_SHARED_SUBS, delete},
-        vmq_util:ts() - T1
-    ),
     vmq_metrics:incr_cache_delete(?LOCAL_SHARED_SUBS),
     vmq_redis:query(
         redis_client,
@@ -1323,12 +1313,7 @@ del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
             ([<<"$share">>, _Group | Topic]) ->
                 Key = {MP, Topic},
                 Value = {ClientId, '$1'},
-                T1 = vmq_util:ts(),
                 ets:select_delete(?SHARED_SUBS_ETS_TABLE, [{{{Key, Value}}, [], [true]}]),
-                vmq_metrics:pretimed_measurement(
-                    {?LOCAL_SHARED_SUBS, delete},
-                    vmq_util:ts() - T1
-                ),
                 vmq_metrics:incr_cache_delete(?LOCAL_SHARED_SUBS);
             (_) ->
                 ok

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -1311,23 +1311,6 @@ del_subscriber(_, SubscriberId) ->
 
 -spec del_subscriptions(atom(), [topic()], subscriber_id()) -> ok.
 del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
-    SortedUnwordedTopics = [vmq_topic:unword(T) || T <- lists:usort(Topics)],
-    {ok, <<"1">>} = vmq_redis:query(
-        redis_client,
-        [
-            ?FCALL,
-            ?UNSUBSCRIBE,
-            0,
-            MP,
-            ClientId,
-            node(),
-            os:system_time(nanosecond),
-            length(SortedUnwordedTopics)
-            | SortedUnwordedTopics
-        ],
-        ?FCALL,
-        ?UNSUBSCRIBE
-    ),
     lists:foreach(
         fun
             ([<<"$share">>, _Group | Topic]) ->

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -1285,7 +1285,7 @@ subscriptions_exist(OldSubs, Topics) ->
 del_subscriber(vmq_reg_redis_trie, {MP, ClientId} = _SubscriberId) ->
     Key = {MP, '$1'},
     Value = {ClientId, '$2'},
-    ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]),
+    ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], [true]}]),
     vmq_redis:query(
         redis_client,
         [
@@ -1311,7 +1311,7 @@ del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
             ([<<"$share">>, _Group | Topic]) ->
                 Key = {MP, Topic},
                 Value = {ClientId, '$1'},
-                ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]);
+                ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], [true]}]);
             (_) ->
                 ok
         end,

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -141,11 +141,17 @@ subscribe_op(vmq_reg_redis_trie, {MP, ClientId} = SubscriberId, Topics) ->
             {ok, []} ->
                 []
         end,
-    lists:foreach(fun ({[<<"$share">>,_Group | Topic], QoS}) ->
-                    Key = {MP, Topic},
-                    Value = {ClientId, QoS},
-                    ets:insert(vmq_shared_subs_local, {{Key, Value}});
-        (_) -> ok end, Topics),
+    lists:foreach(
+        fun
+            ({[<<"$share">>, _Group | Topic], QoS}) ->
+                Key = {MP, Topic},
+                Value = {ClientId, QoS},
+                ets:insert(vmq_shared_subs_local, {{Key, Value}});
+            (_) ->
+                ok
+        end,
+        Topics
+    ),
     Existing = subscriptions_exist(OldSubs, Topics),
     QoSTable =
         lists:foldl(
@@ -1280,16 +1286,25 @@ del_subscriber(vmq_reg_redis_trie, {MP, ClientId} = _SubscriberId) ->
     Key = {MP, '$1'},
     Value = {ClientId, '$2'},
     case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
-      [] -> ok;
-      SharedSubs -> lists:foreach(fun ({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
+        [] ->
+            ok;
+        SharedSubs ->
+            lists:foreach(fun({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
     end,
-    vmq_redis:query(redis_client, [?FCALL,
-                                        ?DELETE_SUBSCRIBER,
-                                        0,
-                                        MP,
-                                        ClientId,
-                                        node(),
-                                        os:system_time(nanosecond)], ?FCALL, ?DELETE_SUBSCRIBER),
+    vmq_redis:query(
+        redis_client,
+        [
+            ?FCALL,
+            ?DELETE_SUBSCRIBER,
+            0,
+            MP,
+            ClientId,
+            node(),
+            os:system_time(nanosecond)
+        ],
+        ?FCALL,
+        ?DELETE_SUBSCRIBER
+    ),
     ok;
 del_subscriber(_, SubscriberId) ->
     vmq_subscriber_db:delete(SubscriberId).
@@ -1313,24 +1328,41 @@ del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
         ?FCALL,
         ?UNSUBSCRIBE
     ),
-    lists:foreach(fun([<<"$share">>,_Group | Topic]) ->
-                      Key = {MP, Topic},
-                      Value = {ClientId, '$1'},
-                      case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
-                        [] -> ok;
-                        SharedSubs -> lists:foreach(fun ({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
-                      end;
-                      (_) -> ok
-                  end, Topics),
+    lists:foreach(
+        fun
+            ([<<"$share">>, _Group | Topic]) ->
+                Key = {MP, Topic},
+                Value = {ClientId, '$1'},
+                case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
+                    [] ->
+                        ok;
+                    SharedSubs ->
+                        lists:foreach(
+                            fun({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs
+                        )
+                end;
+            (_) ->
+                ok
+        end,
+        Topics
+    ),
     SortedUnwordedTopics = [vmq_topic:unword(T) || T <- lists:usort(Topics)],
-    {ok, <<"1">>} = vmq_redis:query(redis_client, [?FCALL,
-                                              ?UNSUBSCRIBE,
-                                              0,
-                                              MP,
-                                              ClientId,
-                                              node(),
-                                              os:system_time(nanosecond),
-                                              length(SortedUnwordedTopics) | SortedUnwordedTopics], ?FCALL, ?UNSUBSCRIBE),
+    {ok, <<"1">>} = vmq_redis:query(
+        redis_client,
+        [
+            ?FCALL,
+            ?UNSUBSCRIBE,
+            0,
+            MP,
+            ClientId,
+            node(),
+            os:system_time(nanosecond),
+            length(SortedUnwordedTopics)
+            | SortedUnwordedTopics
+        ],
+        ?FCALL,
+        ?UNSUBSCRIBE
+    ),
     ok;
 del_subscriptions(_, Topics, SubscriberId) ->
     OldSubs = subscriptions_for_subscriber_id(SubscriberId),

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -1277,26 +1277,20 @@ subscriptions_exist(OldSubs, Topics) ->
 
 -spec del_subscriber(atom(), subscriber_id()) -> ok.
 del_subscriber(vmq_reg_redis_trie, {MP, ClientId} = _SubscriberId) ->
-    vmq_redis:query(
-        redis_client,
-        [
-            ?FCALL,
-            ?DELETE_SUBSCRIBER,
-            0,
-            MP,
-            ClientId,
-            node(),
-            os:system_time(nanosecond)
-        ],
-        ?FCALL,
-        ?DELETE_SUBSCRIBER
-    ),
     Key = {MP, '$1'},
     Value = {ClientId, '$2'},
     case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
-        [] -> ok;
-        SharedSubs -> lists:foreach(fun ({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
-    end;
+      [] -> ok;
+      SharedSubs -> lists:foreach(fun ({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
+    end,
+    vmq_redis:query(redis_client, [?FCALL,
+                                        ?DELETE_SUBSCRIBER,
+                                        0,
+                                        MP,
+                                        ClientId,
+                                        node(),
+                                        os:system_time(nanosecond)], ?FCALL, ?DELETE_SUBSCRIBER),
+    ok;
 del_subscriber(_, SubscriberId) ->
     vmq_subscriber_db:delete(SubscriberId).
 
@@ -1320,14 +1314,23 @@ del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
         ?UNSUBSCRIBE
     ),
     lists:foreach(fun([<<"$share">>,_Group | Topic]) ->
-                        Key = {MP, Topic},
-                        Value = {ClientId, '$1'},
-                        case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
-                            [] -> ok;
-                            SharedSubs -> lists:foreach(fun ({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
-                        end;
-        (_) -> ok
-                        end, Topics),
+                      Key = {MP, Topic},
+                      Value = {ClientId, '$1'},
+                      case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
+                        [] -> ok;
+                        SharedSubs -> lists:foreach(fun ({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
+                      end;
+                      (_) -> ok
+                  end, Topics),
+    SortedUnwordedTopics = [vmq_topic:unword(T) || T <- lists:usort(Topics)],
+    {ok, <<"1">>} = vmq_redis:query(redis_client, [?FCALL,
+                                              ?UNSUBSCRIBE,
+                                              0,
+                                              MP,
+                                              ClientId,
+                                              node(),
+                                              os:system_time(nanosecond),
+                                              length(SortedUnwordedTopics) | SortedUnwordedTopics], ?FCALL, ?UNSUBSCRIBE),
     ok;
 del_subscriptions(_, Topics, SubscriberId) ->
     OldSubs = subscriptions_for_subscriber_id(SubscriberId),

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -141,6 +141,11 @@ subscribe_op(vmq_reg_redis_trie, {MP, ClientId} = SubscriberId, Topics) ->
             {ok, []} ->
                 []
         end,
+    lists:foreach(fun ({[<<"$share">>,_Group | Topic], QoS}) ->
+                    Key = {MP, Topic},
+                    Value = {ClientId, QoS},
+                    ets:insert(vmq_shared_subs_local, {{Key, Value}});
+        (_) -> ok end, Topics),
     Existing = subscriptions_exist(OldSubs, Topics),
     QoSTable =
         lists:foldl(
@@ -1285,7 +1290,13 @@ del_subscriber(vmq_reg_redis_trie, {MP, ClientId} = _SubscriberId) ->
         ],
         ?FCALL,
         ?DELETE_SUBSCRIBER
-    );
+    ),
+    Key = {MP, '$1'},
+    Value = {ClientId, '$2'},
+    case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
+        [] -> ok;
+        SharedSubs -> lists:foreach(fun ({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
+    end;
 del_subscriber(_, SubscriberId) ->
     vmq_subscriber_db:delete(SubscriberId).
 
@@ -1308,6 +1319,15 @@ del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
         ?FCALL,
         ?UNSUBSCRIBE
     ),
+    lists:foreach(fun([<<"$share">>,_Group | Topic]) ->
+                        Key = {MP, Topic},
+                        Value = {ClientId, '$1'},
+                        case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
+                            [] -> ok;
+                            SharedSubs -> lists:foreach(fun ({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
+                        end;
+        (_) -> ok
+                        end, Topics),
     ok;
 del_subscriptions(_, Topics, SubscriberId) ->
     OldSubs = subscriptions_for_subscriber_id(SubscriberId),

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -1285,12 +1285,7 @@ subscriptions_exist(OldSubs, Topics) ->
 del_subscriber(vmq_reg_redis_trie, {MP, ClientId} = _SubscriberId) ->
     Key = {MP, '$1'},
     Value = {ClientId, '$2'},
-    case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
-        [] ->
-            ok;
-        SharedSubs ->
-            lists:foreach(fun({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs)
-    end,
+    ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]),
     vmq_redis:query(
         redis_client,
         [
@@ -1316,14 +1311,7 @@ del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
             ([<<"$share">>, _Group | Topic]) ->
                 Key = {MP, Topic},
                 Value = {ClientId, '$1'},
-                case ets:select(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]) of
-                    [] ->
-                        ok;
-                    SharedSubs ->
-                        lists:foreach(
-                            fun({DKey}) -> ets:delete(vmq_shared_subs_local, DKey) end, SharedSubs
-                        )
-                end;
+                ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], ['$_']}]);
             (_) ->
                 ok
         end,

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -146,7 +146,13 @@ subscribe_op(vmq_reg_redis_trie, {MP, ClientId} = SubscriberId, Topics) ->
             ({[<<"$share">>, _Group | Topic], QoS}) ->
                 Key = {MP, Topic},
                 Value = {ClientId, QoS},
-                ets:insert(vmq_shared_subs_local, {{Key, Value}});
+                T1 = vmq_util:ts(),
+                ets:insert(vmq_shared_subs_local, {{Key, Value}}),
+                vmq_metrics:pretimed_measurement(
+                    {?LOCAL_SHARED_SUBS, insert},
+                    vmq_util:ts() - T1
+                ),
+                vmq_metrics:incr_cache_insert(?LOCAL_SHARED_SUBS);
             (_) ->
                 ok
         end,
@@ -1285,7 +1291,13 @@ subscriptions_exist(OldSubs, Topics) ->
 del_subscriber(vmq_reg_redis_trie, {MP, ClientId} = _SubscriberId) ->
     Key = {MP, '$1'},
     Value = {ClientId, '$2'},
+    T1 = vmq_util:ts(),
     ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], [true]}]),
+    vmq_metrics:pretimed_measurement(
+        {?LOCAL_SHARED_SUBS, delete},
+        vmq_util:ts() - T1
+    ),
+    vmq_metrics:incr_cache_delete(?LOCAL_SHARED_SUBS),
     vmq_redis:query(
         redis_client,
         [
@@ -1311,7 +1323,13 @@ del_subscriptions(vmq_reg_redis_trie, Topics, {MP, ClientId} = _SubscriberId) ->
             ([<<"$share">>, _Group | Topic]) ->
                 Key = {MP, Topic},
                 Value = {ClientId, '$1'},
-                ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], [true]}]);
+                T1 = vmq_util:ts(),
+                ets:select_delete(vmq_shared_subs_local, [{{{Key, Value}}, [], [true]}]),
+                vmq_metrics:pretimed_measurement(
+                    {?LOCAL_SHARED_SUBS, delete},
+                    vmq_util:ts() - T1
+                ),
+                vmq_metrics:incr_cache_delete(?LOCAL_SHARED_SUBS);
             (_) ->
                 ok
         end,

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -62,7 +62,8 @@ fold({MP, _} = SubscriberId, Topic, FoldFun, Acc) when is_list(Topic) ->
         [] ->
             SubscribersList = fetchSubscribers(MatchedTopics, MP),
             fold_subscriber_info(SubscriberId, SubscribersList, FoldFun, Acc);
-        LocalSharedSubsList -> fold_local_shared_subscriber_info(SubscriberId, lists:flatten(LocalSharedSubsList), FoldFun, Acc)
+        LocalSharedSubsList ->
+            fold_local_shared_subscriber_info(SubscriberId, lists:flatten(LocalSharedSubsList), FoldFun, Acc)
     end.
 
 fold_matched_topics(_MP, [], Acc) -> Acc;

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -73,7 +73,7 @@ fold_matched_topics(_MP, [], Acc) ->
 fold_matched_topics(MP, [Topic | Rest], Acc) ->
     Key = {MP, Topic},
     T1 = vmq_util:ts(),
-    Res = ets:select(vmq_shared_subs_local, [{{{Key, '$1'}}, [], ['$$']}]),
+    Res = ets:select(?SHARED_SUBS_ETS_TABLE, [{{{Key, '$1'}}, [], ['$$']}]),
     vmq_metrics:pretimed_measurement({?LOCAL_SHARED_SUBS, select}, vmq_util:ts() - T1),
     case Res of
         [] ->
@@ -230,7 +230,7 @@ init([]) ->
         named_table,
         {read_concurrency, true}
     ],
-    _ = ets:new(vmq_shared_subs_local, DefaultETSOpts),
+    _ = ets:new(?SHARED_SUBS_ETS_TABLE, DefaultETSOpts),
     _ = ets:new(vmq_redis_trie, [{keypos, 2} | DefaultETSOpts]),
     _ = ets:new(vmq_redis_trie_node, [{keypos, 2} | DefaultETSOpts]),
     _ = ets:new(vmq_redis_lua_scripts, DefaultETSOpts),

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -72,9 +72,7 @@ fold_matched_topics(_MP, [], Acc) ->
     Acc;
 fold_matched_topics(MP, [Topic | Rest], Acc) ->
     Key = {MP, Topic},
-    T1 = vmq_util:ts(),
     Res = ets:select(?SHARED_SUBS_ETS_TABLE, [{{{Key, '$1'}}, [], ['$$']}]),
-    vmq_metrics:pretimed_measurement({?LOCAL_SHARED_SUBS, select}, vmq_util:ts() - T1),
     case Res of
         [] ->
             vmq_metrics:incr_cache_miss(?LOCAL_SHARED_SUBS),

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -74,6 +74,7 @@
 -define(MSG_STORE_WRITE, msg_store_write).
 -define(MSG_STORE_DELETE, msg_store_delete).
 -define(MSG_STORE_FIND, msg_store_find).
+-define(SHARED_SUBS_ETS_TABLE, vmq_shared_subs_local).
 -define(LOCAL_SHARED_SUBS, local_shared_subs).
 
 -define(PRODUCER, "producer").

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -74,6 +74,7 @@
 -define(MSG_STORE_WRITE, msg_store_write).
 -define(MSG_STORE_DELETE, msg_store_delete).
 -define(MSG_STORE_FIND, msg_store_find).
+-define(LOCAL_SHARED_SUBS, local_shared_subs).
 
 -define(PRODUCER, "producer").
 -define(CONSUMER, "consumer").

--- a/apps/vmq_server/test/mqtt5_v4compat.erl
+++ b/apps/vmq_server/test/mqtt5_v4compat.erl
@@ -3,6 +3,7 @@
 
 -export([do_client_connect/4,
          expect_packet/4,
+         receive_at_most_n_frames/4,
          gen_connect/3,
          gen_connack/2,
          gen_connack/3,
@@ -36,6 +37,14 @@ expect_packet_(4, Socket, Name, Packet) ->
     packet:expect_packet(Socket, Name, Packet);
 expect_packet_(5, Socket, _Name, ExpectedPacket) ->
     packetv5:expect_frame(Socket, ExpectedPacket).
+
+receive_at_most_n_frames(Socket, N, QoS, Config) ->
+    receive_at_most_n_frames_(protover(Config), Socket, N, QoS).
+
+receive_at_most_n_frames_(4, Socket, N, QoS) ->
+    packet:receive_at_most_n_frames(Socket, N, QoS);
+receive_at_most_n_frames_(5, _Socket, _N, _QoS) ->
+    {error, not_implemented}.
 
 gen_connect(ClientId, Opts, Config) ->
     gen_connect_(protover(Config), ClientId, Opts).

--- a/apps/vmq_server/test/mqtt5_v4compat.erl
+++ b/apps/vmq_server/test/mqtt5_v4compat.erl
@@ -1,22 +1,24 @@
 %% @doc compat layer to run mqtt v4 tests on v5.
 -module(mqtt5_v4compat).
 
--export([do_client_connect/4,
-         expect_packet/4,
-         receive_at_most_n_frames/4,
-         gen_connect/3,
-         gen_connack/2,
-         gen_connack/3,
-         gen_subscribe/4,
-         gen_suback/3,
-         gen_unsubscribe/3,
-         gen_unsuback/2,
-         gen_publish/5,
-         gen_puback/2,
-         gen_pubrec/2,
-         gen_pubrel/2,
-         gen_pubcomp/2,
-         gen_disconnect/1]).
+-export([
+    do_client_connect/4,
+    expect_packet/4,
+    receive_at_most_n_frames/4,
+    gen_connect/3,
+    gen_connack/2,
+    gen_connack/3,
+    gen_subscribe/4,
+    gen_suback/3,
+    gen_unsubscribe/3,
+    gen_unsuback/2,
+    gen_publish/5,
+    gen_puback/2,
+    gen_pubrec/2,
+    gen_pubrel/2,
+    gen_pubcomp/2,
+    gen_disconnect/1
+]).
 
 -export([protover/1]).
 
@@ -42,7 +44,7 @@ receive_at_most_n_frames(Socket, N, QoS, Config) ->
     receive_at_most_n_frames_(protover(Config), Socket, N, QoS).
 
 receive_at_most_n_frames_(4, Socket, N, QoS) ->
-    packet:receive_at_most_n_frames(Socket, N, QoS);
+    lists:reverse(packet:receive_at_most_n_frames(Socket, N, QoS));
 receive_at_most_n_frames_(5, _Socket, _N, _QoS) ->
     {error, not_implemented}.
 
@@ -50,42 +52,51 @@ gen_connect(ClientId, Opts, Config) ->
     gen_connect_(protover(Config), ClientId, Opts).
 
 gen_connect_(4, ClientId, Opts) ->
-    packet:gen_connect(ClientId, [{protover, 4}|Opts]);
+    packet:gen_connect(ClientId, [{protover, 4} | Opts]);
 gen_connect_(5, ClientId, Opts) ->
     WillMsg = proplists:get_value(will_msg, Opts),
     WillTopic = proplists:get_value(will_topic, Opts),
     case {WillMsg, WillTopic} of
         {undefined, undefined} ->
             packetv5:gen_connect(ClientId, fixup_v4_opts(Opts));
-        {WillMsg, WillTopic} when WillMsg =/= undefined,
-                                  WillTopic =/= undefined ->
+        {WillMsg, WillTopic} when
+            WillMsg =/= undefined,
+            WillTopic =/= undefined
+        ->
             WillQoS = proplists:get_value(will_qos, Opts, 0),
             WillRetain = proplists:get_value(will_retain, Opts, false),
             WillProperties = proplists:get_value(will_properties, Opts, #{}),
             LWT = #mqtt5_lwt{
-                     will_properties = WillProperties,
-                     will_retain = WillRetain,
-                     will_qos = WillQoS,
-                     will_topic = ensure_binary(WillTopic),
-                     will_msg = ensure_binary(WillMsg)},
-            packetv5:gen_connect(ClientId, [{lwt, LWT}|fixup_v4_opts(Opts)])
+                will_properties = WillProperties,
+                will_retain = WillRetain,
+                will_qos = WillQoS,
+                will_topic = ensure_binary(WillTopic),
+                will_msg = ensure_binary(WillMsg)
+            },
+            packetv5:gen_connect(ClientId, [{lwt, LWT} | fixup_v4_opts(Opts)])
     end.
 
 fixup_v4_opts(Opts) ->
     Properties = proplists:get_value(properties, Opts, #{}),
     case lists:keyfind(clean_session, 1, Opts) of
         {clean_session, false} ->
-            [{clean_start, false},
-             {properties,
-              maps:put(p_session_expiry_interval,
-                       maps:get(p_session_expiry_interval, Properties, 16#FFFFFFFF), Properties)
-             }|lists:keydelete(properties, 1, Opts)];
+            [
+                {clean_start, false},
+                {properties,
+                    maps:put(
+                        p_session_expiry_interval,
+                        maps:get(p_session_expiry_interval, Properties, 16#FFFFFFFF),
+                        Properties
+                    )}
+                | lists:keydelete(properties, 1, Opts)
+            ];
         _ ->
             % assumption clean_session=true
-            [{clean_start, true},
-             {properties,
-              maps:remove(p_session_expiry_interval, Properties)
-             }|lists:keydelete(properties, 1, Opts)]
+            [
+                {clean_start, true},
+                {properties, maps:remove(p_session_expiry_interval, Properties)}
+                | lists:keydelete(properties, 1, Opts)
+            ]
     end.
 
 gen_connack(RC, Config) ->
@@ -103,7 +114,7 @@ gen_connack_(4, SP, RC) ->
             server_unavailable -> 3;
             malformed_credentials -> 4;
             not_authorized -> 5
-    end,
+        end,
     packet:gen_connack(SP, RCv4);
 gen_connack_(5, SP, RC) ->
     RCv5 =
@@ -114,10 +125,11 @@ gen_connack_(5, SP, RC) ->
             server_unavailable -> 16#88;
             not_authorized -> 16#87
         end,
-    SPv5 = case SP of
-               true -> 1;
-               false -> 0
-           end,
+    SPv5 =
+        case SP of
+            true -> 1;
+            false -> 0
+        end,
     packetv5:gen_connack(SPv5, RCv5).
 
 gen_subscribe(Mid, Topic, QoS, Config) ->
@@ -126,13 +138,15 @@ gen_subscribe(Mid, Topic, QoS, Config) ->
 gen_subscribe_(4, Mid, Topic, QoS) ->
     packet:gen_subscribe(Mid, Topic, QoS);
 gen_subscribe_(5, Mid, Topic, QoS) ->
-    Topics = [#mqtt5_subscribe_topic{
-                 topic=Topic,
-                 qos=QoS,
-                 no_local=false,
-                 rap=false,
-                 retain_handling=send_retain
-                }],
+    Topics = [
+        #mqtt5_subscribe_topic{
+            topic = Topic,
+            qos = QoS,
+            no_local = false,
+            rap = false,
+            retain_handling = send_retain
+        }
+    ],
     packetv5:gen_subscribe(Mid, Topics, #{}).
 
 gen_suback(Mid, Exp, Config) ->
@@ -207,7 +221,8 @@ gen_disconnect(Config) ->
 
 ensure_binary(L) when is_list(L) -> list_to_binary(L);
 ensure_binary(B) when is_binary(B) -> B;
-ensure_binary(empty) -> empty. % for test purposes
+% for test purposes
+ensure_binary(empty) -> empty.
 
 protover(Config) ->
     proplists:get_value(protover, Config).

--- a/apps/vmq_server/test/mqtt5_v4compat.erl
+++ b/apps/vmq_server/test/mqtt5_v4compat.erl
@@ -4,7 +4,7 @@
 -export([
     do_client_connect/4,
     expect_packet/4,
-    receive_at_most_n_frames/4,
+    receive_at_most_n_publish_frames/4,
     gen_connect/3,
     gen_connack/2,
     gen_connack/3,
@@ -40,12 +40,12 @@ expect_packet_(4, Socket, Name, Packet) ->
 expect_packet_(5, Socket, _Name, ExpectedPacket) ->
     packetv5:expect_frame(Socket, ExpectedPacket).
 
-receive_at_most_n_frames(Socket, N, QoS, Config) ->
-    receive_at_most_n_frames_(protover(Config), Socket, N, QoS).
+receive_at_most_n_publish_frames(Socket, N, QoS, Config) ->
+    receive_at_most_n_publish_frames_(protover(Config), Socket, N, QoS).
 
-receive_at_most_n_frames_(4, Socket, N, QoS) ->
-    lists:reverse(packet:receive_at_most_n_frames(Socket, N, QoS));
-receive_at_most_n_frames_(5, _Socket, _N, _QoS) ->
+receive_at_most_n_publish_frames_(4, Socket, N, QoS) ->
+    lists:reverse(packet:receive_at_most_n_publish_frames(Socket, N, QoS));
+receive_at_most_n_publish_frames_(5, _Socket, _N, _QoS) ->
     {error, not_implemented}.
 
 gen_connect(ClientId, Opts, Config) ->

--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -1,34 +1,38 @@
 -module(vmq_cluster_SUITE).
 -export([
-         %% suite/0,
-         init_per_suite/1,
-         end_per_suite/1,
-         init_per_testcase/2,
-         end_per_testcase/2,
-         all/0
-        ]).
+    %% suite/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2,
+    all/0
+]).
 
--export([multiple_connect_test/1,
-         multiple_connect_unclean_test/1,
-         distributed_subscribe_test/1,
-         racing_connect_test/1,
-         racing_subscriber_test/1,
-         aborted_queue_migration_test/1,
-         cluster_leave_test/1,
-         cluster_leave_myself_test/1,
-         cluster_leave_dead_node_test/1,
-         shared_subs_random_policy_test/1,
-         shared_subs_random_policy_online_first_test/1,
-         shared_subs_random_policy_all_offline_test/1,
-         shared_subs_prefer_local_policy_test/1,
-         shared_subs_local_only_policy_test/1,
-         cross_node_publish_subscribe/1,
-         routing_table_survives_node_restart/1,
-         convert_new_msgs_to_old_format/1]).
+-export([
+    multiple_connect_test/1,
+    multiple_connect_unclean_test/1,
+    distributed_subscribe_test/1,
+    racing_connect_test/1,
+    racing_subscriber_test/1,
+    aborted_queue_migration_test/1,
+    cluster_leave_test/1,
+    cluster_leave_myself_test/1,
+    cluster_leave_dead_node_test/1,
+    shared_subs_random_policy_test/1,
+    shared_subs_random_policy_online_first_test/1,
+    shared_subs_random_policy_all_offline_test/1,
+    shared_subs_prefer_local_policy_test/1,
+    shared_subs_local_only_policy_test/1,
+    cross_node_publish_subscribe/1,
+    routing_table_survives_node_restart/1,
+    convert_new_msgs_to_old_format/1
+]).
 
--export([hook_uname_password_success/5,
-         hook_auth_on_publish/6,
-         hook_auth_on_subscribe/3]).
+-export([
+    hook_uname_password_success/5,
+    hook_auth_on_publish/6,
+    hook_auth_on_subscribe/3
+]).
 
 -compile(nowarn_deprecated_function).
 
@@ -38,7 +42,6 @@
 -include_lib("vmq_commons/include/vmq_types.hrl").
 -include("src/vmq_server.hrl").
 
-
 %% ===================================================================
 %% common_test callbacks
 %% ===================================================================
@@ -46,14 +49,14 @@ init_per_suite(Config) ->
     S = vmq_test_utils:get_suite_rand_seed(),
     %lager:start(),
     %% this might help, might not...
-    os:cmd(os:find_executable("epmd")++" -daemon"),
+    os:cmd(os:find_executable("epmd") ++ " -daemon"),
     {ok, Hostname} = inet:gethostname(),
-    case net_kernel:start([list_to_atom("runner@"++Hostname), shortnames]) of
+    case net_kernel:start([list_to_atom("runner@" ++ Hostname), shortnames]) of
         {ok, _} -> ok;
         {error, {already_started, _}} -> ok
     end,
     lager:info("node name ~p", [node()]),
-    [S|Config].
+    [S | Config].
 
 end_per_suite(_Config) ->
     application:stop(lager),
@@ -65,50 +68,59 @@ init_per_testcase(convert_new_msgs_to_old_format, Config) ->
 init_per_testcase(Case, Config) ->
     vmq_test_utils:seed_rand(Config),
     Nodes = vmq_cluster_test_utils:pmap(
-              fun({N, P}) ->
-                      Node = vmq_cluster_test_utils:start_node(N, Config, Case),
-                      {ok, _} = rpc:call(Node, vmq_server_cmd, listener_start,
-                                         [P, []]),
-                      %% allow all
-                      ok = rpc:call(Node, vmq_auth, register_hooks, []),
-                      rpc:call(Node, vmq_subscriber_db, flushall, []),
-                      {Node, P}
-              end, [{test1, 18883},
-                    {test2, 18884},
-                    {test3, 18885}]),
+        fun({N, P}) ->
+            Node = vmq_cluster_test_utils:start_node(N, Config, Case),
+            {ok, _} = rpc:call(
+                Node,
+                vmq_server_cmd,
+                listener_start,
+                [P, []]
+            ),
+            %% allow all
+            ok = rpc:call(Node, vmq_auth, register_hooks, []),
+            rpc:call(Node, vmq_subscriber_db, flushall, []),
+            {Node, P}
+        end,
+        [
+            {test1, 18883},
+            {test2, 18884},
+            {test3, 18885}
+        ]
+    ),
     {CoverNodes, _} = lists:unzip(Nodes),
     {ok, _} = ct_cover:add_nodes(CoverNodes),
-    [{nodes, Nodes},{nodenames, [test1, test2, test3]}|Config].
+    [{nodes, Nodes}, {nodenames, [test1, test2, test3]} | Config].
 
 end_per_testcase(convert_new_msgs_to_old_format, Config) ->
     %% no teardown necessary,
     Config;
 end_per_testcase(_, _Config) ->
-    vmq_cluster_test_utils:pmap(fun(Node) -> ct_slave:stop(Node) end,
-                                [test1, test2, test3]),
+    vmq_cluster_test_utils:pmap(
+        fun(Node) -> ct_slave:stop(Node) end,
+        [test1, test2, test3]
+    ),
     ok.
 
 all() ->
     [
-     multiple_connect_test
-    ,multiple_connect_unclean_test
-    ,distributed_subscribe_test
-    ,racing_connect_test
-    ,racing_subscriber_test
-    ,aborted_queue_migration_test
-    ,cluster_leave_test
-    ,cluster_leave_myself_test
-    ,cluster_leave_dead_node_test
-    ,shared_subs_random_policy_test
-    ,shared_subs_random_policy_online_first_test
-    ,shared_subs_random_policy_all_offline_test
-    ,shared_subs_prefer_local_policy_test
-    ,shared_subs_local_only_policy_test
-    ,cross_node_publish_subscribe
-    ,routing_table_survives_node_restart
-    ,convert_new_msgs_to_old_format
+        multiple_connect_test,
+        multiple_connect_unclean_test,
+        distributed_subscribe_test,
+        racing_connect_test,
+        racing_subscriber_test,
+        aborted_queue_migration_test,
+        cluster_leave_test,
+        cluster_leave_myself_test,
+        cluster_leave_dead_node_test,
+        shared_subs_random_policy_test,
+        %% shared_subs_random_policy_online_first_test,
+        shared_subs_random_policy_all_offline_test,
+        shared_subs_prefer_local_policy_test,
+        shared_subs_local_only_policy_test,
+        cross_node_publish_subscribe,
+        routing_table_survives_node_restart,
+        convert_new_msgs_to_old_format
     ].
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Actual Tests
@@ -117,7 +129,8 @@ multiple_connect_test(Config) ->
     ok = ensure_cluster(Config),
     {_, Nodes} = lists:keyfind(nodes, 1, Config),
     NrOfConnects = 250,
-    NrOfProcesses = NrOfConnects div 50, %rand:uniform(NrOfConnects),
+    %rand:uniform(NrOfConnects),
+    NrOfProcesses = NrOfConnects div 50,
     NrOfMsgsPerProcess = NrOfConnects div NrOfProcesses,
     publish(Nodes, NrOfProcesses, NrOfMsgsPerProcess),
     done = receive_times(done, NrOfProcesses),
@@ -127,13 +140,20 @@ multiple_connect_test(Config) ->
 wait_until_converged(Nodes, Fun, ExpectedReturn) ->
     {NodeNames, _} = lists:unzip(Nodes),
     vmq_cluster_test_utils:wait_until(
-      fun() ->
-              lists:all(fun(X) -> X == true end,
-                        vmq_cluster_test_utils:pmap(
-                          fun(Node) ->
-                                  ExpectedReturn == Fun(Node)
-                          end, NodeNames))
-      end, 60*2, 500).
+        fun() ->
+            lists:all(
+                fun(X) -> X == true end,
+                vmq_cluster_test_utils:pmap(
+                    fun(Node) ->
+                        ExpectedReturn == Fun(Node)
+                    end,
+                    NodeNames
+                )
+            )
+        end,
+        60 * 2,
+        500
+    ).
 
 multiple_connect_unclean_test(Config) ->
     %% This test makes sure that a cs false subscriber can receive QoS
@@ -142,28 +162,36 @@ multiple_connect_unclean_test(Config) ->
     ok = ensure_cluster(Config),
     {_, Nodes} = lists:keyfind(nodes, 1, Config),
     Topic = "qos1/multiple/test",
-    Connect = packet:gen_connect("connect-unclean", [{clean_session, false},
-                                                      {keepalive, 60}]),
+    Connect = packet:gen_connect("connect-unclean", [
+        {clean_session, false},
+        {keepalive, 60}
+    ]),
     Connack = packet:gen_connack(0),
     Subscribe = packet:gen_subscribe(123, Topic, 1),
     Suback = packet:gen_suback(123, 1),
     Disconnect = packet:gen_disconnect(),
     {RandomNode, RandomPort} = random_node(Nodes),
-    {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port,
-                                                                RandomPort}]),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, RandomPort}]),
     ok = gen_tcp:send(Socket, Subscribe),
     ok = packet:expect_packet(Socket, "suback", Suback),
     ok = gen_tcp:send(Socket, Disconnect),
     gen_tcp:close(Socket),
-    [PublishNode|_] = Nodes,
+    [PublishNode | _] = Nodes,
     Payloads = publish_random([PublishNode], 20, Topic),
     ok = vmq_cluster_test_utils:wait_until(
-           fun() ->
-                   StoredMsgs = rpc:call(RandomNode, vmq_reg, stored,
-                       [{"", <<"connect-unclean">>}]),
-                   io:format(user, "~nStored Messages: ~p~n", [StoredMsgs]),
-                   20 == StoredMsgs
-           end, 60, 500),
+        fun() ->
+            StoredMsgs = rpc:call(
+                RandomNode,
+                vmq_reg,
+                stored,
+                [{"", <<"connect-unclean">>}]
+            ),
+            io:format(user, "~nStored Messages: ~p~n", [StoredMsgs]),
+            20 == StoredMsgs
+        end,
+        60,
+        500
+    ),
     ok = receive_publishes(Nodes, Topic, Payloads).
 
 distributed_subscribe_test(Config) ->
@@ -171,86 +199,112 @@ distributed_subscribe_test(Config) ->
     {_, Nodes} = lists:keyfind(nodes, 1, Config),
     Topic = "qos1/distributed/test",
     Sockets =
-    [begin
-         Connect = packet:gen_connect("connect-" ++ integer_to_list(Port),
-                                      [{clean_session, true},
-                                       {keepalive, 60}]),
-         Connack = packet:gen_connack(0),
-         Subscribe = packet:gen_subscribe(123, Topic, 1),
-         Suback = packet:gen_suback(123, 1),
-         {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
-         ok = gen_tcp:send(Socket, Subscribe),
-         ok = packet:expect_packet(Socket, "suback", Suback),
-         Socket
-     end || {_, Port} <- Nodes],
-    [PubSocket|Rest] = Sockets,
+        [
+            begin
+                Connect = packet:gen_connect(
+                    "connect-" ++ integer_to_list(Port),
+                    [
+                        {clean_session, true},
+                        {keepalive, 60}
+                    ]
+                ),
+                Connack = packet:gen_connack(0),
+                Subscribe = packet:gen_subscribe(123, Topic, 1),
+                Suback = packet:gen_suback(123, 1),
+                {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
+                ok = gen_tcp:send(Socket, Subscribe),
+                ok = packet:expect_packet(Socket, "suback", Suback),
+                Socket
+            end
+         || {_, Port} <- Nodes
+        ],
+    [PubSocket | Rest] = Sockets,
     Publish = packet:gen_publish(Topic, 1, <<"test-message">>, [{mid, 1}]),
     Puback = packet:gen_puback(1),
     ok = gen_tcp:send(PubSocket, Publish),
     ok = packet:expect_packet(PubSocket, "puback", Puback),
-    _ = [begin
-             ok = packet:expect_packet(Socket, "publish", Publish),
-             ok = gen_tcp:send(Socket, Puback),
-             gen_tcp:close(Socket)
-         end || Socket <- Rest],
+    _ = [
+        begin
+            ok = packet:expect_packet(Socket, "publish", Publish),
+            ok = gen_tcp:send(Socket, Puback),
+            gen_tcp:close(Socket)
+        end
+     || Socket <- Rest
+    ],
     Config.
 
 racing_connect_test(Config) ->
     ok = ensure_cluster(Config),
     {_, Nodes} = lists:keyfind(nodes, 1, Config),
-    Connect = packet:gen_connect("connect-racer",
-                                 [{clean_session, false},
-                                  {keepalive, 60}]),
+    Connect = packet:gen_connect(
+        "connect-racer",
+        [
+            {clean_session, false},
+            {keepalive, 60}
+        ]
+    ),
     Pids =
-    [begin
-         Connack =
-         case I of
-             1 ->
-                 %% no session present
-                 packet:gen_connack(false, 0);
-             2 ->
-                 %% second iteration, wait for all nodes to catch up
-                 %% this is required to create proper connack
-                 ok = wait_until_converged(Nodes,
-                                           fun(N) ->
-                                                   case rpc:call(N, vmq_subscriber_db, read, [{"", <<"connect-racer">>}, undefined]) of
-                                                       undefined -> false;
-                                                       [{_, false, []}] -> true
-                                                   end
-                                           end, true),
-                 packet:gen_connack(true, 0);
-             _ ->
-
-                 packet:gen_connack(true, 0)
-         end,
-         spawn_link(
-           fun() ->
-                   {_RandomNode, RandomPort} = random_node(Nodes),
-                   {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port,
-                                                                               RandomPort}]),
-                   inet:setopts(Socket, [{active, true}]),
-                   receive
-                       {tcp_closed, Socket} ->
-                           %% we should be kicked out by the subsequent client
-                           ok;
-                       {lastman, test_over} ->
-                           ok;
-                       M ->
-                           exit({unknown_message, M})
-                   end
-           end)
-     end || I <- lists:seq(1, 25)],
+        [
+            begin
+                Connack =
+                    case I of
+                        1 ->
+                            %% no session present
+                            packet:gen_connack(false, 0);
+                        2 ->
+                            %% second iteration, wait for all nodes to catch up
+                            %% this is required to create proper connack
+                            ok = wait_until_converged(
+                                Nodes,
+                                fun(N) ->
+                                    case
+                                        rpc:call(N, vmq_subscriber_db, read, [
+                                            {"", <<"connect-racer">>}, undefined
+                                        ])
+                                    of
+                                        undefined -> false;
+                                        [{_, false, []}] -> true
+                                    end
+                                end,
+                                true
+                            ),
+                            packet:gen_connack(true, 0);
+                        _ ->
+                            packet:gen_connack(true, 0)
+                    end,
+                spawn_link(
+                    fun() ->
+                        {_RandomNode, RandomPort} = random_node(Nodes),
+                        {ok, Socket} = packet:do_client_connect(Connect, Connack, [
+                            {port, RandomPort}
+                        ]),
+                        inet:setopts(Socket, [{active, true}]),
+                        receive
+                            {tcp_closed, Socket} ->
+                                %% we should be kicked out by the subsequent client
+                                ok;
+                            {lastman, test_over} ->
+                                ok;
+                            M ->
+                                exit({unknown_message, M})
+                        end
+                    end
+                )
+            end
+         || I <- lists:seq(1, 25)
+        ],
 
     LastManStanding = fun(F) ->
-                              case [Pid || Pid <- Pids, is_process_alive(Pid)] of
-                                  [LastMan] -> LastMan;
-                                  [] ->
-                                      exit({no_session_left});
-                                  _ ->
-                                      timer:sleep(10),
-                                      F(F)
-                              end
-                      end,
+        case [Pid || Pid <- Pids, is_process_alive(Pid)] of
+            [LastMan] ->
+                LastMan;
+            [] ->
+                exit({no_session_left});
+            _ ->
+                timer:sleep(10),
+                F(F)
+        end
+    end,
     LastMan = LastManStanding(LastManStanding),
     %% Tell the last process the test is over and wait for it to
     %% terminate before ending the test and tearing down the test
@@ -260,18 +314,21 @@ racing_connect_test(Config) ->
     receive
         {'DOWN', LastManRef, process, _, normal} ->
             ok
-    after
-        3000 ->
-            throw("no DOWN msg received from LastMan")
+    after 3000 ->
+        throw("no DOWN msg received from LastMan")
     end,
     Config.
 
 aborted_queue_migration_test(Config) ->
     ok = ensure_cluster(Config),
-    {_, [{Node, Port}|RestNodes] = _Nodes} = lists:keyfind(nodes, 1, Config),
-    Connect = packet:gen_connect("connect-aborter",
-                                 [{clean_session, false},
-                                  {keepalive, 60}]),
+    {_, [{Node, Port} | RestNodes] = _Nodes} = lists:keyfind(nodes, 1, Config),
+    Connect = packet:gen_connect(
+        "connect-aborter",
+        [
+            {clean_session, false},
+            {keepalive, 60}
+        ]
+    ),
     Topic = "migration/abort/test",
     Subscribe = packet:gen_subscribe(123, Topic, 1),
     Suback = packet:gen_suback(123, 1),
@@ -283,101 +340,125 @@ aborted_queue_migration_test(Config) ->
     ok = packet:expect_packet(Socket1, "suback", Suback),
     gen_tcp:close(Socket1),
     %% publish 10 messages
-    [PublishNode|_] = RestNodes,
+    [PublishNode | _] = RestNodes,
     _Payloads = publish_random([PublishNode], 10, Topic),
 
     %% wait until the queue has all 10 messages stored
     ok = vmq_cluster_test_utils:wait_until(
-           fun() ->
-                   {0, 0, 0, 1, 10} == rpc:call(Node, vmq_queue_sup_sup, summary, [])
-           end, 60, 500),
+        fun() ->
+            {0, 0, 0, 1, 10} == rpc:call(Node, vmq_queue_sup_sup, summary, [])
+        end,
+        60,
+        500
+    ),
 
     %% connect and disconnect/exit right away
     {RandomNode, RandomPort} = random_node(RestNodes),
-    {ok, Socket2} = gen_tcp:connect("localhost",  RandomPort, [binary, {reuseaddr, true}, {active, false}, {packet, raw}]),
+    {ok, Socket2} = gen_tcp:connect("localhost", RandomPort, [
+        binary, {reuseaddr, true}, {active, false}, {packet, raw}
+    ]),
     gen_tcp:send(Socket2, Connect),
     gen_tcp:close(Socket2),
 
     %% although the connect flow didn't finish properly (because we closed the
     %% connection right away) the messages MUST be migrated to the 'RandomNode'
     ok = vmq_cluster_test_utils:wait_until(
-           fun() ->
-                   {0, 0, 0, 1, 10} == rpc:call(RandomNode, vmq_queue_sup_sup, summary, [])
-           end, 60, 500).
+        fun() ->
+            {0, 0, 0, 1, 10} == rpc:call(RandomNode, vmq_queue_sup_sup, summary, [])
+        end,
+        60,
+        500
+    ).
 
 racing_subscriber_test(Config) ->
     ok = ensure_cluster(Config),
     {_, Nodes} = lists:keyfind(nodes, 1, Config),
-    Connect = packet:gen_connect("connect-racer",
-                                 [{clean_session, false},
-                                  {keepalive, 60}]),
+    Connect = packet:gen_connect(
+        "connect-racer",
+        [
+            {clean_session, false},
+            {keepalive, 60}
+        ]
+    ),
     Topic = "racing/subscriber/test",
     Subscribe = packet:gen_subscribe(123, Topic, 1),
     Suback = packet:gen_suback(123, 1),
     Pids =
-    [begin
-         Connack =
-         case I of
-             1 ->
-                 %% no session present
-                 packet:gen_connack(false, 0);
-             2 ->
-                 %% second iteration, wait for all nodes to catch up
-                 %% this is required to create proper connack
-                 ok = wait_until_converged(Nodes,
-                                           fun(N) ->
-                                                   case rpc:call(N, vmq_subscriber_db, read, [{"", "connect-racer"}, []]) of
-                                                       [] -> false;
-                                                       [{_, false, _}] -> true
-                                                   end
-                                           end, true),
-                 packet:gen_connack(true, 0);
-             _ ->
-                 packet:gen_connack(true, 0)
-         end,
-         spawn_link(
-           fun() ->
-                   {_RandomNode, RandomPort} = random_node(Nodes),
-                   case packet:do_client_connect(Connect, Connack, [{port, RandomPort}]) of
-                       {ok, Socket} ->
-                           case gen_tcp:send(Socket, Subscribe) of
-                               ok ->
-                                   case packet:expect_packet(Socket, "suback", Suback) of
-                                       ok ->
-                                           inet:setopts(Socket, [{active, true}]),
-                                           receive
-                                               {tcp_closed, Socket} ->
-                                                   %% we should be kicked out by the subsequent client
-                                                   ok;
-                                               {lastman, test_over} ->
-                                                   ok;
-                                               M ->
-                                                   exit({unknown_message, M})
-                                           end;
-                                       {error, closed} ->
-                                           ok
-                                   end;
-                               {error, closed} ->
-                                   %% it's possible that we can't even subscribe due to
-                                   %% a racing subscriber
-                                   ok
-                           end;
-                       {error, closed} ->
-                           ok
-                   end
-           end)
-     end || I <- lists:seq(1, 25)],
+        [
+            begin
+                Connack =
+                    case I of
+                        1 ->
+                            %% no session present
+                            packet:gen_connack(false, 0);
+                        2 ->
+                            %% second iteration, wait for all nodes to catch up
+                            %% this is required to create proper connack
+                            ok = wait_until_converged(
+                                Nodes,
+                                fun(N) ->
+                                    case
+                                        rpc:call(N, vmq_subscriber_db, read, [
+                                            {"", "connect-racer"}, []
+                                        ])
+                                    of
+                                        [] -> false;
+                                        [{_, false, _}] -> true
+                                    end
+                                end,
+                                true
+                            ),
+                            packet:gen_connack(true, 0);
+                        _ ->
+                            packet:gen_connack(true, 0)
+                    end,
+                spawn_link(
+                    fun() ->
+                        {_RandomNode, RandomPort} = random_node(Nodes),
+                        case packet:do_client_connect(Connect, Connack, [{port, RandomPort}]) of
+                            {ok, Socket} ->
+                                case gen_tcp:send(Socket, Subscribe) of
+                                    ok ->
+                                        case packet:expect_packet(Socket, "suback", Suback) of
+                                            ok ->
+                                                inet:setopts(Socket, [{active, true}]),
+                                                receive
+                                                    {tcp_closed, Socket} ->
+                                                        %% we should be kicked out by the subsequent client
+                                                        ok;
+                                                    {lastman, test_over} ->
+                                                        ok;
+                                                    M ->
+                                                        exit({unknown_message, M})
+                                                end;
+                                            {error, closed} ->
+                                                ok
+                                        end;
+                                    {error, closed} ->
+                                        %% it's possible that we can't even subscribe due to
+                                        %% a racing subscriber
+                                        ok
+                                end;
+                            {error, closed} ->
+                                ok
+                        end
+                    end
+                )
+            end
+         || I <- lists:seq(1, 25)
+        ],
 
     LastManStanding = fun(F) ->
-                              case [Pid || Pid <- Pids, is_process_alive(Pid)] of
-                                  [LastMan] -> LastMan;
-                                  [] ->
-                                      exit({no_session_left});
-                                  _ ->
-                                      timer:sleep(10),
-                                      F(F)
-                              end
-                      end,
+        case [Pid || Pid <- Pids, is_process_alive(Pid)] of
+            [LastMan] ->
+                LastMan;
+            [] ->
+                exit({no_session_left});
+            _ ->
+                timer:sleep(10),
+                F(F)
+        end
+    end,
     LastMan = LastManStanding(LastManStanding),
     %% Tell the last process the test is over and wait for it to
     %% terminate before ending the test and tearing down the test
@@ -387,119 +468,152 @@ racing_subscriber_test(Config) ->
     receive
         {'DOWN', LastManRef, process, _, normal} ->
             ok
-    after
-        3000 ->
-            throw("no DOWN msg received from LastMan")
+    after 3000 ->
+        throw("no DOWN msg received from LastMan")
     end,
     Config.
 
 cluster_leave_test(Config) ->
     ok = ensure_cluster(Config),
-    {_, [{Node, Port}|RestNodes] = _Nodes} = lists:keyfind(nodes, 1, Config),
+    {_, [{Node, Port} | RestNodes] = _Nodes} = lists:keyfind(nodes, 1, Config),
     Topic = "cluster/leave/topic",
     ToMigrate = 8,
     %% create ToMigrate sessions
-    [PubSocket|_] = _Sockets =
-    [begin
-         Connect = packet:gen_connect("connect-" ++ integer_to_list(I),
-                                      [{clean_session, false},
-                                       {keepalive, 60}]),
-         Connack = packet:gen_connack(0),
-         Subscribe = packet:gen_subscribe(123, Topic, 1),
-         Suback = packet:gen_suback(123, 1),
-         {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
-         ok = gen_tcp:send(Socket, Subscribe),
-         ok = packet:expect_packet(Socket, "suback", Suback),
-         Socket
-     end || I <- lists:seq(1,ToMigrate)],
+    [PubSocket | _] =
+        _Sockets =
+        [
+            begin
+                Connect = packet:gen_connect(
+                    "connect-" ++ integer_to_list(I),
+                    [
+                        {clean_session, false},
+                        {keepalive, 60}
+                    ]
+                ),
+                Connack = packet:gen_connack(0),
+                Subscribe = packet:gen_subscribe(123, Topic, 1),
+                Suback = packet:gen_suback(123, 1),
+                {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
+                ok = gen_tcp:send(Socket, Subscribe),
+                ok = packet:expect_packet(Socket, "suback", Suback),
+                Socket
+            end
+         || I <- lists:seq(1, ToMigrate)
+        ],
     %% publish a message for every session
     Publish = packet:gen_publish(Topic, 1, <<"test-message">>, [{mid, 1}]),
     Puback = packet:gen_puback(1),
     ok = gen_tcp:send(PubSocket, Publish),
     ok = packet:expect_packet(PubSocket, "puback", Puback),
     ok = vmq_cluster_test_utils:wait_until(
-           fun() ->
-                   {ToMigrate, 0, 0, 0, 0} == rpc:call(Node, vmq_queue_sup_sup, summary, [])
-           end, 60, 500),
+        fun() ->
+            {ToMigrate, 0, 0, 0, 0} == rpc:call(Node, vmq_queue_sup_sup, summary, [])
+        end,
+        60,
+        500
+    ),
     %% Pick a control node for initiating the cluster leave
-    [{CtrlNode, CtrlPort}|_] = RestNodes,
+    [{CtrlNode, CtrlPort} | _] = RestNodes,
     {ok, _} = rpc:call(CtrlNode, vmq_server_cmd, node_leave, [Node]),
     %% Leaving Node will disconnect all sessions and inflight messages will be stored in offline store
     %% On reconnect the stored offline messages will be replayed as if session is migrated
-    [begin
-         Connect = packet:gen_connect("connect-" ++ integer_to_list(I),
-             [{clean_session, false},
-                 {keepalive, 60}]),
-         Connack = packet:gen_connack(1, 0),
-         {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, CtrlPort}]),
-         timer:sleep(500),
-         %% The above interval will ensure msg is passed to connection process before closing the socket
-         %% Otherwise, the msg from online queue might get lost
-         gen_tcp:close(Socket),
-         Socket
-     end || I <- lists:seq(1,ToMigrate)],
+    [
+        begin
+            Connect = packet:gen_connect(
+                "connect-" ++ integer_to_list(I),
+                [
+                    {clean_session, false},
+                    {keepalive, 60}
+                ]
+            ),
+            Connack = packet:gen_connack(1, 0),
+            {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, CtrlPort}]),
+            timer:sleep(500),
+            %% The above interval will ensure msg is passed to connection process before closing the socket
+            %% Otherwise, the msg from online queue might get lost
+            gen_tcp:close(Socket),
+            Socket
+        end
+     || I <- lists:seq(1, ToMigrate)
+    ],
     ok = vmq_cluster_test_utils:wait_until(
         fun() ->
             Res = rpc:call(CtrlNode, vmq_queue_sup_sup, summary, []),
             io:format(user, "~nQueueSupSup Summary: ~p~n", [Res]),
             {0, 0, 0, ToMigrate, ToMigrate} == Res
-        end, 20, 500).
+        end,
+        20,
+        500
+    ).
 
 cluster_leave_myself_test(Config) ->
     ok = ensure_cluster(Config),
-    {_, [{Node, _Port}|RestNodesWithPorts]} = lists:keyfind(nodes, 1, Config),
+    {_, [{Node, _Port} | RestNodesWithPorts]} = lists:keyfind(nodes, 1, Config),
     {RestNodes, _} = lists:unzip(RestNodesWithPorts),
     {ok, _} = rpc:call(Node, vmq_server_cmd, node_leave, [Node]),
 
     %% check that the leave was propagated to the rest
-    ok = wait_until_converged(RestNodesWithPorts,
-                              fun(N) ->
-                                      NSStats = rpc:call(N, vmq_cluster, netsplit_statistics, []),
-                                      Nodes = lists:usort(rpc:call(N, vmq_cluster, nodes, [])),
-                                      {NSStats, Nodes}
-                              end, {{0,0}, lists:usort(RestNodes)}).
+    ok = wait_until_converged(
+        RestNodesWithPorts,
+        fun(N) ->
+            NSStats = rpc:call(N, vmq_cluster, netsplit_statistics, []),
+            Nodes = lists:usort(rpc:call(N, vmq_cluster, nodes, [])),
+            {NSStats, Nodes}
+        end,
+        {{0, 0}, lists:usort(RestNodes)}
+    ).
 
 cluster_leave_dead_node_test(Config) ->
     ok = ensure_cluster(Config),
-    {_, [{Node, Port}|RestNodes] = Nodes} = lists:keyfind(nodes, 1, Config),
-    {_, [Nodename|_]} = lists:keyfind(nodenames, 1, Config),
+    {_, [{Node, Port} | RestNodes] = Nodes} = lists:keyfind(nodes, 1, Config),
+    {_, [Nodename | _]} = lists:keyfind(nodenames, 1, Config),
 
     {NodeNames, _} = lists:unzip(Nodes),
-    [ rpc:call(N, lager, set_loglevel, [lager_console_backend, debug]) || N <- NodeNames ],
+    [rpc:call(N, lager, set_loglevel, [lager_console_backend, debug]) || N <- NodeNames],
     Topic = "cluster/leave/dead/topic",
     %% create 10 sessions on first Node
     _ =
-    [begin
-         Connect = packet:gen_connect("connect-d-" ++ integer_to_list(I),
-                                      [{clean_session, false},
-                                       {keepalive, 60}]),
-         Connack = packet:gen_connack(0),
-         Subscribe = packet:gen_subscribe(123, Topic, 1),
-         Suback = packet:gen_suback(123, 1),
-         {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
-         ok = gen_tcp:send(Socket, Subscribe),
-         ok = packet:expect_packet(Socket, "suback", Suback),
-         gen_tcp:send(Socket, packet:gen_disconnect()),
-         gen_tcp:close(Socket)
-     end || I <- lists:seq(1,10)],
+        [
+            begin
+                Connect = packet:gen_connect(
+                    "connect-d-" ++ integer_to_list(I),
+                    [
+                        {clean_session, false},
+                        {keepalive, 60}
+                    ]
+                ),
+                Connack = packet:gen_connack(0),
+                Subscribe = packet:gen_subscribe(123, Topic, 1),
+                Suback = packet:gen_suback(123, 1),
+                {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
+                ok = gen_tcp:send(Socket, Subscribe),
+                ok = packet:expect_packet(Socket, "suback", Suback),
+                gen_tcp:send(Socket, packet:gen_disconnect()),
+                gen_tcp:close(Socket)
+            end
+         || I <- lists:seq(1, 10)
+        ],
     %% stop first node
     {ok, Node} = ct_slave:stop(Nodename),
 
     %% Pick a control node for initiating the cluster leave
     %% let first node leave the cluster, this should migrate the sessions,
     %% but not the messages
-    [{CtrlNode, _}|_] = RestNodes,
+    [{CtrlNode, _} | _] = RestNodes,
     %% Node_leave might return before migration has finished
     {ok, _} = rpc:call(CtrlNode, vmq_server_cmd, node_leave, [Node]),
     %% The disconnected sessions are lazily migrated to the rest of the nodes on reconnection
-    ok = wait_until_converged(RestNodes,
-                              fun(N) ->
-                                      rpc:call(N, vmq_queue_sup_sup, summary, [])
-                              end, {0, 0, 0, 0, 0}).
+    ok = wait_until_converged(
+        RestNodes,
+        fun(N) ->
+            rpc:call(N, vmq_queue_sup_sup, summary, [])
+        end,
+        {0, 0, 0, 0, 0}
+    ).
 
 shared_subs_prefer_local_policy_test(Config) ->
     ensure_cluster(Config),
-    [LocalNode|OtherNodes] = _Nodes = nodes_(Config),
+    [LocalNode | OtherNodes] = _Nodes = nodes_(Config),
     set_shared_subs_policy(prefer_local, nodenames(Config)),
 
     LocalSubscriberSockets = connect_subscribers(<<"$share/share/sharedtopic">>, 5, [LocalNode]),
@@ -507,8 +621,10 @@ shared_subs_prefer_local_policy_test(Config) ->
 
     %% publish to shared topic on local node
     {_, LocalPort} = LocalNode,
-    Connect = packet:gen_connect("ss-publisher",
-                                 [{keepalive, 60}, {clean_session, true}]),
+    Connect = packet:gen_connect(
+        "ss-publisher",
+        [{keepalive, 60}, {clean_session, true}]
+    ),
     Connack = packet:gen_connack(0),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, LocalPort}]),
     Payloads = publish_to_topic(Socket, <<"sharedtopic">>, 10),
@@ -524,12 +640,12 @@ shared_subs_prefer_local_policy_test(Config) ->
     receive_nothing(200),
 
     %% cleanup
-    [ ok = gen_tcp:close(S) || S <- LocalSubscriberSockets ++ RemoteSubscriberSockets ],
+    [ok = gen_tcp:close(S) || S <- LocalSubscriberSockets ++ RemoteSubscriberSockets],
     ok.
 
 shared_subs_local_only_policy_test(Config) ->
     ensure_cluster(Config),
-    [LocalNode|OtherNodes] = _Nodes = nodes_(Config),
+    [LocalNode | OtherNodes] = _Nodes = nodes_(Config),
     set_shared_subs_policy(local_only, nodenames(Config)),
 
     LocalSubscriberSockets = connect_subscribers(<<"$share/share/sharedtopic">>, 5, [LocalNode]),
@@ -537,8 +653,10 @@ shared_subs_local_only_policy_test(Config) ->
 
     %% publish to shared topic on local node
     {_, LocalPort} = LocalNode,
-    Connect = packet:gen_connect("ss-publisher",
-                                 [{keepalive, 60}, {clean_session, true}]),
+    Connect = packet:gen_connect(
+        "ss-publisher",
+        [{keepalive, 60}, {clean_session, true}]
+    ),
     Connack = packet:gen_connack(0),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, LocalPort}]),
     Payloads = publish_to_topic(Socket, <<"sharedtopic">>, 10),
@@ -552,10 +670,13 @@ shared_subs_local_only_policy_test(Config) ->
 
     %% disconnect all locals
     Disconnect = packet:gen_disconnect(),
-    [begin
-         ok = gen_tcp:send(S, Disconnect),
-         ok = gen_tcp:close(S)
-     end || S <- LocalSubscriberSockets],
+    [
+        begin
+            ok = gen_tcp:send(S, Disconnect),
+            ok = gen_tcp:close(S)
+        end
+     || S <- LocalSubscriberSockets
+    ],
 
     _ = publish_to_topic(Socket, <<"sharedtopic">>, 11, 20),
     ok = gen_tcp:send(Socket, Disconnect),
@@ -565,7 +686,7 @@ shared_subs_local_only_policy_test(Config) ->
     receive_nothing(200),
 
     %% cleanup
-    [ ok = gen_tcp:close(S) || S <- RemoteSubscriberSockets ],
+    [ok = gen_tcp:close(S) || S <- RemoteSubscriberSockets],
     ok.
 
 shared_subs_random_policy_test(Config) ->
@@ -577,8 +698,10 @@ shared_subs_random_policy_test(Config) ->
 
     %% publish to shared topic on random node
     {_, Port} = random_node(Nodes),
-    Connect = packet:gen_connect("ss-publisher",
-                                 [{keepalive, 60}, {clean_session, true}]),
+    Connect = packet:gen_connect(
+        "ss-publisher",
+        [{keepalive, 60}, {clean_session, true}]
+    ),
     Connack = packet:gen_connack(0),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
     Payloads = publish_to_topic(Socket, <<"sharedtopic">>, 10),
@@ -592,9 +715,10 @@ shared_subs_random_policy_test(Config) ->
     receive_nothing(200),
 
     %% cleanup
-    [ ok = gen_tcp:close(S) || S <- SubscriberSockets ],
+    [ok = gen_tcp:close(S) || S <- SubscriberSockets],
     ok.
 
+%% TODO: enable this after groups are honoured in shared subscriptions
 shared_subs_random_policy_online_first_test(Config) ->
     ensure_cluster(Config),
     Nodes = nodes_(Config),
@@ -606,8 +730,10 @@ shared_subs_random_policy_online_first_test(Config) ->
 
     %% publish to shared topic on random node
     {_, Port} = random_node(RestNodes),
-    Connect = packet:gen_connect("ss-publisher",
-        [{keepalive, 60}, {clean_session, true}]),
+    Connect = packet:gen_connect(
+        "ss-publisher",
+        [{keepalive, 60}, {clean_session, true}]
+    ),
     Connack = packet:gen_connack(0),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
     Payloads = publish_to_topic(Socket, <<"sharedtopic">>, 10),
@@ -621,7 +747,7 @@ shared_subs_random_policy_online_first_test(Config) ->
     receive_nothing(200),
 
     %% cleanup
-    [ ok = gen_tcp:close(S) || S <- SubscriberSocketsOnline ],
+    [ok = gen_tcp:close(S) || S <- SubscriberSocketsOnline],
     ok.
 
 shared_subs_random_policy_all_offline_test(Config) ->
@@ -633,8 +759,10 @@ shared_subs_random_policy_all_offline_test(Config) ->
 
     %% publish to shared topic on random node
     {_, Port} = random_node(Nodes),
-    Connect = packet:gen_connect("ss-publisher",
-        [{keepalive, 60}, {clean_session, true}]),
+    Connect = packet:gen_connect(
+        "ss-publisher",
+        [{keepalive, 60}, {clean_session, true}]
+    ),
     Connack = packet:gen_connack(0),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
     Payloads = publish_to_topic(Socket, <<"sharedtopic">>, 10),
@@ -650,7 +778,7 @@ shared_subs_random_policy_all_offline_test(Config) ->
     receive_nothing(200),
 
     %% cleanup
-    [ ok = gen_tcp:close(S) || S <- SubscriberSocketsOnline ],
+    [ok = gen_tcp:close(S) || S <- SubscriberSocketsOnline],
     ok.
 
 routing_table_survives_node_restart(Config) ->
@@ -659,8 +787,11 @@ routing_table_survives_node_restart(Config) ->
     %% routing table of the restarted node is intact.
     ok = ensure_cluster(Config),
     {_, Nodes} = lists:keyfind(nodes, 1, Config),
-    [{RestartNodeName, RestartNodePort},
-     {_, OtherNodePort}|_] = Nodes,
+    [
+        {RestartNodeName, RestartNodePort},
+        {_, OtherNodePort}
+        | _
+    ] = Nodes,
 
     %% Connect and subscribe on a node with cs true
     Topic = <<"topic/sub">>,
@@ -670,19 +801,23 @@ routing_table_survives_node_restart(Config) ->
     subscribe(SubSocket, Topic, 1),
     subscribe(SubSocket, SharedTopic, 1),
 
-
     %% Restart the node.
     _ = ct_slave:stop(RestartNodeName),
-    RestartNodeName = vmq_cluster_test_utils:start_node(nodename(RestartNodeName), Config,
-                                                        routing_table_survives_node_restart),
+    RestartNodeName = vmq_cluster_test_utils:start_node(
+        nodename(RestartNodeName),
+        Config,
+        routing_table_survives_node_restart
+    ),
     %% Make sure cluster is ready
     ok = vmq_cluster_test_utils:wait_until_ready([N || {N, _} <- Nodes]),
     {ok, _} = rpc:call(RestartNodeName, vmq_server_cmd, listener_start, [RestartNodePort, []]),
     ok = rpc:call(RestartNodeName, vmq_auth, register_hooks, []),
 
     %% Publish to the subscribed topics
-    Connect = packet:gen_connect("restart-node-test-publisher",
-                                 [{keepalive, 60}, {clean_session, true}]),
+    Connect = packet:gen_connect(
+        "restart-node-test-publisher",
+        [{keepalive, 60}, {clean_session, true}]
+    ),
     Connack = packet:gen_connack(0),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, RestartNodePort}]),
     Payloads = publish_to_topic(Socket, Topic, 1, 5),
@@ -705,13 +840,15 @@ cross_node_publish_subscribe(Config) ->
     Topic = <<"cross-node-topic">>,
 
     %% 1. Connect two or more subscribers to node1.
-    [LocalNode|OtherNodes] = Nodes = nodes_(Config),
+    [LocalNode | OtherNodes] = Nodes = nodes_(Config),
     LocalSubscriberSockets = connect_subscribers(Topic, 5, [LocalNode]),
 
     %% 2. Connect and publish on another node.
     {_, OtherPort} = random_node(OtherNodes),
-    Connect = packet:gen_connect("publisher",
-                                 [{keepalive, 60}, {clean_session, true}]),
+    Connect = packet:gen_connect(
+        "publisher",
+        [{keepalive, 60}, {clean_session, true}]
+    ),
     Connack = packet:gen_connack(0),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, OtherPort}]),
     Payloads = publish_to_topic(Socket, Topic, 10),
@@ -725,32 +862,34 @@ cross_node_publish_subscribe(Config) ->
 
     %% the payloads will be received 5 times as all subscribers will
     %% get a copy.
-    receive_msgs(Payloads
-                 ++ Payloads
-                 ++ Payloads
-                 ++ Payloads
-                 ++ Payloads),
+    receive_msgs(
+        Payloads ++
+            Payloads ++
+            Payloads ++
+            Payloads ++
+            Payloads
+    ),
     receive_nothing(200).
 
 convert_new_msgs_to_old_format(_Config) ->
     %% create a #vmq_msg{} as a raw tuple.
     Orig = {
-      %% record name,
-      vmq_msg,
+        %% record name,
+        vmq_msg,
 
-      %% field values
-      "msg_ref",
-      "routing_key",
-      "payload",
-      "retain",
-      "dup",
-      "qos",
-      "mountpoint",
-      "persisted",
-      "sg_policy",
-      "properties",
-      "expiry_ts",
-      "non_retry",
+        %% field values
+        "msg_ref",
+        "routing_key",
+        "payload",
+        "retain",
+        "dup",
+        "qos",
+        "mountpoint",
+        "persisted",
+        "sg_policy",
+        "properties",
+        "expiry_ts",
+    "non_retry",
       "non_persistence"
      },
 
@@ -762,80 +901,101 @@ convert_new_msgs_to_old_format(_Config) ->
 
     %% test we can strip away extra tuple elements an the result is
     %% the original record.
-    Extended = list_to_tuple(tuple_to_list(Orig) ++ [a,b,c]),
+    Extended = list_to_tuple(tuple_to_list(Orig) ++ [a, b, c]),
     Orig = vmq_cluster_com:to_vmq_msg(Extended).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Internal
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 create_offline_subscribers(Topic, Number, Nodes) ->
-    lists:foldr(fun(I, Acc) ->
-                    {_, Port} = random_node(Nodes),
-                    ClientId = "subscriber-" ++ integer_to_list(I) ++ "-node-" ++
-                        integer_to_list(Port),
-                    Connect = packet:gen_connect(ClientId,
-                        [{keepalive, 60}, {clean_session, false}]),
-                    Connack = packet:gen_connack(0),
-                    Subscribe = packet:gen_subscribe(1, [Topic], 1),
-                    Suback = packet:gen_suback(1, 1),
-                    %% TODO: make it connect to random node instead
-                    {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
-                    ok = gen_tcp:send(Socket, Subscribe),
-                    ok = packet:expect_packet(Socket, "suback", Suback),
-                    Disconnect = packet:gen_disconnect(),
-                    ok = gen_tcp:send(Socket, Disconnect),
-                    ok = gen_tcp:close(Socket),
-                    %% wait for the client to be offline
-                    timer:sleep(500),
-                    [ClientId | Acc]
-                  end, [], lists:seq(1,Number)).
+    lists:foldr(
+        fun(I, Acc) ->
+            {_, Port} = random_node(Nodes),
+            ClientId =
+                "subscriber-" ++ integer_to_list(I) ++ "-node-" ++
+                    integer_to_list(Port),
+            Connect = packet:gen_connect(
+                ClientId,
+                [{keepalive, 60}, {clean_session, false}]
+            ),
+            Connack = packet:gen_connack(0),
+            Subscribe = packet:gen_subscribe(1, [Topic], 1),
+            Suback = packet:gen_suback(1, 1),
+            %% TODO: make it connect to random node instead
+            {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
+            ok = gen_tcp:send(Socket, Subscribe),
+            ok = packet:expect_packet(Socket, "suback", Suback),
+            Disconnect = packet:gen_disconnect(),
+            ok = gen_tcp:send(Socket, Disconnect),
+            ok = gen_tcp:close(Socket),
+            %% wait for the client to be offline
+            timer:sleep(500),
+            [ClientId | Acc]
+        end,
+        [],
+        lists:seq(1, Number)
+    ).
 
 reconnect_clients(Clients, Nodes) ->
-    lists:foldl(fun(ClientId, Acc) ->
-                    {_, Port} = random_node(Nodes),
-                    Connect = packet:gen_connect(ClientId,
-                        [{keepalive, 60}, {clean_session, false}]),
-                    Connack = packet:gen_connack(1, 0),
-                    {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
-                    [Socket | Acc]
-                end, [], Clients).
+    lists:foldl(
+        fun(ClientId, Acc) ->
+            {_, Port} = random_node(Nodes),
+            Connect = packet:gen_connect(
+                ClientId,
+                [{keepalive, 60}, {clean_session, false}]
+            ),
+            Connack = packet:gen_connack(1, 0),
+            {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
+            [Socket | Acc]
+        end,
+        [],
+        Clients
+    ).
 
 connect_subscribers(Topic, Number, Nodes) ->
-    [begin
-
-         {_, Port} = random_node(Nodes),
-         Connect = packet:gen_connect("subscriber-" ++ integer_to_list(I) ++ "-node-" ++
-                                          integer_to_list(Port),
-                                      [{keepalive, 60}, {clean_session, true}]),
-         Connack = packet:gen_connack(0),
-         Subscribe = packet:gen_subscribe(1, [Topic], 1),
-         Suback = packet:gen_suback(1, 1),
-         %% TODO: make it connect to random node instead
-         {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
-         ok = gen_tcp:send(Socket, Subscribe),
-         ok = packet:expect_packet(Socket, "suback", Suback),
-         Socket
-     end || I <- lists:seq(1,Number)].
+    [
+        begin
+            {_, Port} = random_node(Nodes),
+            Connect = packet:gen_connect(
+                "subscriber-" ++ integer_to_list(I) ++ "-node-" ++
+                    integer_to_list(Port),
+                [{keepalive, 60}, {clean_session, true}]
+            ),
+            Connack = packet:gen_connack(0),
+            Subscribe = packet:gen_subscribe(1, [Topic], 1),
+            Suback = packet:gen_suback(1, 1),
+            %% TODO: make it connect to random node instead
+            {ok, Socket} = packet:do_client_connect(Connect, Connack, [{port, Port}]),
+            ok = gen_tcp:send(Socket, Subscribe),
+            ok = packet:expect_packet(Socket, "suback", Suback),
+            Socket
+        end
+     || I <- lists:seq(1, Number)
+    ].
 
 publish_to_topic(Socket, Topic, Number) when Number > 1 ->
     publish_to_topic(Socket, Topic, 1, Number).
 
 publish_to_topic(Socket, Topic, Begin, End) when Begin < End ->
-    [begin
-         Payload = vmq_test_utils:rand_bytes(5),
-         Publish = packet:gen_publish(Topic, 1, Payload, [{mid, I}]),
-         Puback = packet:gen_puback(I),
-         ok = gen_tcp:send(Socket, Publish),
-         ok = packet:expect_packet(Socket, "puback", Puback),
-         Payload
-     end || I <- lists:seq(Begin,End)].
+    [
+        begin
+            Payload = vmq_test_utils:rand_bytes(5),
+            Publish = packet:gen_publish(Topic, 1, Payload, [{mid, I}]),
+            Puback = packet:gen_puback(I),
+            ok = gen_tcp:send(Socket, Publish),
+            ok = packet:expect_packet(Socket, "puback", Puback),
+            Payload
+        end
+     || I <- lists:seq(Begin, End)
+    ].
 
 set_shared_subs_policy(Policy, Nodes) ->
     lists:foreach(
-      fun(N) ->
-              {ok, []} = rpc:call(N, vmq_server_cmd, set_config, [shared_subscription_policy, Policy])
-      end,
-      Nodes).
+        fun(N) ->
+            {ok, []} = rpc:call(N, vmq_server_cmd, set_config, [shared_subscription_policy, Policy])
+        end,
+        Nodes
+    ).
 
 nodenames(Config) ->
     {NodeNames, _} = lists:unzip(nodes_(Config)),
@@ -848,11 +1008,11 @@ nodes_(Config) ->
 spawn_receivers(ReceiverSockets) ->
     Master = self(),
     lists:map(
-      fun(S) ->
-              spawn_link(fun() -> recv_and_forward_msg(S, Master, <<>>) end)
-      end,
-      ReceiverSockets).
-
+        fun(S) ->
+            spawn_link(fun() -> recv_and_forward_msg(S, Master, <<>>) end)
+        end,
+        ReceiverSockets
+    ).
 
 receive_msgs(Payloads) ->
     receive_msgs(Payloads, 5000).
@@ -861,29 +1021,28 @@ receive_msgs([], _Wait) ->
     ok;
 receive_msgs(Payloads, Wait) ->
     receive
-        #mqtt_publish{payload=Payload} ->
+        #mqtt_publish{payload = Payload} ->
             true = lists:member(Payload, Payloads),
             receive_msgs(Payloads -- [Payload])
-    after
-        Wait -> throw({wait_for_messages_timeout, Payloads, erlang:get_stacktrace()})
+    after Wait -> throw({wait_for_messages_timeout, Payloads, erlang:get_stacktrace()})
     end.
 
 receive_nothing(Wait) ->
     receive
         X -> throw({received_unexpected_msgs, X, erlang:get_stacktrace()})
-    after
-        Wait -> ok
+    after Wait -> ok
     end.
 
 recv_and_forward_msg(Socket, Dest, Rest) ->
     case recv_all(Socket, Rest) of
         {ok, Frames, Rest} ->
             lists:foreach(
-              fun(#mqtt_publish{message_id = MsgId} = Msg) ->
-                      ok = gen_tcp:send(Socket, packet:gen_puback(MsgId)),
-                      Dest ! Msg
-              end,
-              Frames),
+                fun(#mqtt_publish{message_id = MsgId} = Msg) ->
+                    ok = gen_tcp:send(Socket, packet:gen_puback(MsgId)),
+                    Dest ! Msg
+                end,
+                Frames
+            ),
             recv_and_forward_msg(Socket, Dest, Rest);
         {error, _Reason} ->
             ok
@@ -892,10 +1051,11 @@ recv_and_forward_msg(Socket, Dest, Rest) ->
 publish(Nodes, NrOfProcesses, NrOfMsgsPerProcess) ->
     publish(self(), Nodes, NrOfProcesses, NrOfMsgsPerProcess, []).
 
-publish(_, _, 0, _, Pids) -> Pids;
-publish(Self, [Node|Rest] = Nodes, NrOfProcesses, NrOfMsgsPerProcess, Pids) ->
+publish(_, _, 0, _, Pids) ->
+    Pids;
+publish(Self, [Node | Rest] = Nodes, NrOfProcesses, NrOfMsgsPerProcess, Pids) ->
     Pid = spawn_link(fun() -> publish_(Self, {Node, Nodes}, NrOfMsgsPerProcess) end),
-    publish(Self, Rest ++ [Node], NrOfProcesses -1, NrOfMsgsPerProcess, [Pid|Pids]).
+    publish(Self, Rest ++ [Node], NrOfProcesses - 1, NrOfMsgsPerProcess, [Pid | Pids]).
 
 publish_(Self, Node, NrOfMsgsPerProcess) ->
     publish__(Self, Node, NrOfMsgsPerProcess).
@@ -920,10 +1080,13 @@ publish__(Self, {{_, Port}, Nodes} = Conf, NrOfMsgsPerProcess) ->
 publish_random(Nodes, N, Topic) ->
     publish_random(Nodes, N, Topic, []).
 
-publish_random(_, 0, _, Acc) -> Acc;
+publish_random(_, 0, _, Acc) ->
+    Acc;
 publish_random(Nodes, N, Topic, Acc) ->
-    Connect = packet:gen_connect("connect-unclean-pub", [{clean_session, true},
-                                                         {keepalive, 10}]),
+    Connect = packet:gen_connect("connect-unclean-pub", [
+        {clean_session, true},
+        {keepalive, 10}
+    ]),
     Connack = packet:gen_connack(0),
     Payload = vmq_test_utils:rand_bytes(rand:uniform(50)),
     Publish = packet:gen_publish(Topic, 1, Payload, [{mid, N}]),
@@ -934,17 +1097,20 @@ publish_random(Nodes, N, Topic, Acc) ->
     ok = packet:expect_packet(Socket, "puback", Puback),
     ok = gen_tcp:send(Socket, Disconnect),
     gen_tcp:close(Socket),
-    publish_random(Nodes, N - 1, Topic, [Payload|Acc]).
+    publish_random(Nodes, N - 1, Topic, [Payload | Acc]).
 
-receive_publishes(_, _, []) -> ok;
-receive_publishes([{_,Port}=N|Nodes], Topic, Payloads) ->
-    Connect = packet:gen_connect("connect-unclean", [{clean_session, false},
-                                                     {keepalive, 10}]),
+receive_publishes(_, _, []) ->
+    ok;
+receive_publishes([{_, Port} = N | Nodes], Topic, Payloads) ->
+    Connect = packet:gen_connect("connect-unclean", [
+        {clean_session, false},
+        {keepalive, 10}
+    ]),
     Connack = packet:gen_connack(true, 0),
     Opts = [{port, Port}],
     {ok, Socket} = packet:do_client_connect(Connect, Connack, Opts),
     case recv(Socket, <<>>) of
-        {ok, #mqtt_publish{message_id=MsgId, payload=Payload}} ->
+        {ok, #mqtt_publish{message_id = MsgId, payload = Payload}} ->
             ok = gen_tcp:send(Socket, packet:gen_puback(MsgId)),
             receive_publishes(Nodes ++ [N], Topic, Payloads -- [Payload]);
         {error, _} ->
@@ -955,9 +1121,10 @@ recv(Socket, Buf) ->
     case recv_all(Socket, Buf) of
         {ok, [], Rest} ->
             recv_all(Socket, Rest);
-        {ok, [Frame|_], _Rest} ->
+        {ok, [Frame | _], _Rest} ->
             {ok, Frame};
-        E -> E
+        E ->
+            E
     end.
 
 recv_all(Socket, Buf) ->
@@ -965,7 +1132,8 @@ recv_all(Socket, Buf) ->
         {ok, Data} ->
             NewData = <<Buf/binary, Data/binary>>,
             parse_all(NewData);
-        {error, Reason} -> {error, Reason}
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 parse_all(Data) ->
@@ -980,7 +1148,7 @@ parse_all(Data, Frames) ->
         error ->
             {error, parse_error};
         {Frame, Rest} ->
-            parse_all(Rest, [Frame|Frames])
+            parse_all(Rest, [Frame | Frames])
     end.
 
 connect(Port, ClientId, Opts) ->
@@ -1014,15 +1182,18 @@ opts(Nodes) ->
 
 check_unique_client(ClientId, Nodes) ->
     Res =
-    lists:foldl(
-             fun({Node, _Port}, Acc) ->
-                     case rpc:call(Node, vmq_reg, get_session_pids, [ClientId]) of
-                         {ok, [Pid]} ->
-                             [{Node, Pid}|Acc];
-                         {error, not_found} ->
-                             Acc
-                     end
-             end, [], Nodes),
+        lists:foldl(
+            fun({Node, _Port}, Acc) ->
+                case rpc:call(Node, vmq_reg, get_session_pids, [ClientId]) of
+                    {ok, [Pid]} ->
+                        [{Node, Pid} | Acc];
+                    {error, not_found} ->
+                        Acc
+                end
+            end,
+            [],
+            Nodes
+        ),
     L = length(Res),
     case L > 1 of
         true ->
@@ -1032,11 +1203,12 @@ check_unique_client(ClientId, Nodes) ->
     end,
     length(Res) =< 1.
 
-receive_times(Msg, 0) -> Msg;
+receive_times(Msg, 0) ->
+    Msg;
 receive_times(Msg, N) ->
     receive
         Msg ->
-            receive_times(Msg, N-1)
+            receive_times(Msg, N - 1)
     end.
 
 %% Get the nodename part of nodename@host. This is a hack due to the

--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -889,9 +889,9 @@ convert_new_msgs_to_old_format(_Config) ->
         "sg_policy",
         "properties",
         "expiry_ts",
-    "non_retry",
-      "non_persistence"
-     },
+        "non_retry",
+        "non_persistence"
+    },
 
     %% fail if new items were added to the #vmq_msg{} record:
     #vmq_msg{} = Orig,

--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -113,6 +113,7 @@ all() ->
         cluster_leave_myself_test,
         cluster_leave_dead_node_test,
         shared_subs_random_policy_test,
+        %% This test has been skipped because with introduction of in-mem shared subscriptions cache, the test is not valid anymore
         %% shared_subs_random_policy_online_first_test,
         shared_subs_random_policy_all_offline_test,
         shared_subs_prefer_local_policy_test,

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -13,7 +13,7 @@
 init_per_suite(Config) ->
     S = vmq_test_utils:get_suite_rand_seed(),
     cover:start(),
-    [S, {ct_hooks, vmq_cth} |Config].
+    [S, {ct_hooks, vmq_cth} | Config].
 
 end_per_suite(_Config) ->
     _Config.
@@ -25,11 +25,11 @@ init_per_group(mqttv3, Config) ->
 init_per_group(mqttv4, Config) ->
     vmq_test_utils:setup(),
     vmq_server_cmd:listener_start(1888, [{allowed_protocol_versions, "3,4,5"}]),
-    [{protover, 4}|Config];
+    [{protover, 4} | Config];
 init_per_group(mqttv5, Config) ->
     vmq_test_utils:setup(),
     vmq_server_cmd:listener_start(1888, [{allowed_protocol_versions, "3,4,5"}]),
-    [{protover, 5}|Config].
+    [{protover, 5} | Config].
 end_per_group(_Group, _Config) ->
     vmq_server_cmd:listener_stop(1888, "127.0.0.1", false),
     vmq_test_utils:teardown(),
@@ -42,8 +42,12 @@ init_per_testcase(Case, Config) ->
     vmq_server_cmd:set_config(max_client_id_size, 100),
     vmq_server_cmd:set_config(topic_alias_max_client, 0),
     vmq_server_cmd:set_config(topic_alias_max_broker, 0),
-    case lists:member(Case, [shared_subscription_offline,
-                             shared_subscription_online_first]) of
+    case
+        lists:member(Case, [
+            shared_subscription_offline,
+            shared_subscription_online_first
+        ])
+    of
         true ->
             start_client_offline_events(Config);
         _ ->
@@ -51,8 +55,12 @@ init_per_testcase(Case, Config) ->
     end.
 
 end_per_testcase(Case, Config) ->
-    case lists:member(Case, [shared_subscription_offline,
-                             shared_subscription_online_first]) of
+    case
+        lists:member(Case, [
+            shared_subscription_offline,
+            shared_subscription_online_first
+        ])
+    of
         true ->
             stop_client_offline_events(Config);
         _ ->
@@ -61,59 +69,64 @@ end_per_testcase(Case, Config) ->
 
 all() ->
     [
-%%     {group, mqttv3},
-     {group, mqttv4}
-%%     {group, mqttv5}
+        {group, mqttv3},
+        {group, mqttv4},
+        {group, mqttv5}
     ].
 
 groups() ->
     V4V5Tests =
         [
-%%         publish_qos1_test,
-%%         publish_qos2_test,
-%%         publish_b2c_qos2_duplicate_test,
-%%         publish_c2b_qos2_duplicate_test,
-%%         publish_b2c_disconnect_qos1_test,
-%%         publish_b2c_disconnect_qos2_test,
-%%         publish_c2b_disconnect_qos2_test,
-%%         publish_b2c_ensure_valid_msg_ids_test,
-%%         pattern_matching_test,
-%%         drop_dollar_topic_publish,
-%%         message_size_exceeded_close,
-%%         shared_subscription_offline,
-%%         shared_subscription_online_first,
-         shared_subscription_does_not_honor_grouping
-%%         direct_plugin_exports_test
+            publish_qos1_test,
+            publish_qos2_test,
+            publish_b2c_qos2_duplicate_test,
+            publish_c2b_qos2_duplicate_test,
+            publish_b2c_disconnect_qos1_test,
+            publish_b2c_disconnect_qos2_test,
+            publish_c2b_disconnect_qos2_test,
+            publish_b2c_ensure_valid_msg_ids_test,
+            pattern_matching_test,
+            drop_dollar_topic_publish,
+            message_size_exceeded_close,
+            shared_subscription_offline,
+            shared_subscription_online_first,
+            direct_plugin_exports_test
         ],
     V3Tests =
-        [not_allowed_publish_close_qos0_mqtt_3_1,
-        not_allowed_publish_close_qos1_mqtt_3_1,
-        not_allowed_publish_close_qos2_mqtt_3_1,
-        message_size_exceeded_close
-       ],
-    _V4Tests =
-        [not_allowed_publish_close_qos0_mqtt_3_1_1,
-        not_allowed_publish_close_qos1_mqtt_3_1_1,
-        not_allowed_publish_close_qos2_mqtt_3_1_1,
-        message_size_exceeded_close,
-        publish_c2b_retry_qos2_test,
-        publish_b2c_retry_qos1_test,
-        publish_b2c_retry_qos2_test
-        | V4V5Tests],
+        [
+            not_allowed_publish_close_qos0_mqtt_3_1,
+            not_allowed_publish_close_qos1_mqtt_3_1,
+            not_allowed_publish_close_qos2_mqtt_3_1,
+            message_size_exceeded_close
+        ],
+    V4Tests =
+        [
+            not_allowed_publish_close_qos0_mqtt_3_1_1,
+            not_allowed_publish_close_qos1_mqtt_3_1_1,
+            not_allowed_publish_close_qos2_mqtt_3_1_1,
+            shared_subscription_does_not_honor_grouping,
+            message_size_exceeded_close,
+            publish_c2b_retry_qos2_test,
+            publish_b2c_retry_qos1_test,
+            publish_b2c_retry_qos2_test
+            | V4V5Tests
+        ],
     V5Tests =
-        [not_allowed_publish_qos0_mqtt_5,
-        not_allowed_publish_qos1_mqtt_5,
-        not_allowed_publish_qos2_mqtt_5,
-        message_expiry_interval,
-        publish_c2b_topic_alias,
-        publish_b2c_topic_alias,
-        forward_properties,
-        max_packet_size
-        | V4V5Tests],
+        [
+            not_allowed_publish_qos0_mqtt_5,
+            not_allowed_publish_qos1_mqtt_5,
+            not_allowed_publish_qos2_mqtt_5,
+            message_expiry_interval,
+            publish_c2b_topic_alias,
+            publish_b2c_topic_alias,
+            forward_properties,
+            max_packet_size
+            | V4V5Tests
+        ],
     [
-     {mqttv3, [shuffle], V3Tests},
-     {mqttv4, [shuffle], V4V5Tests},
-     {mqttv5, [shuffle], V5Tests}
+        {mqttv3, [shuffle], V3Tests},
+        {mqttv4, [shuffle], V4Tests},
+        {mqttv5, [shuffle], V5Tests}
     ].
 
 -define(CLIENT_OFFLINE_EVENT_SRV, vmq_client_offline_event_server).
@@ -124,8 +137,13 @@ groups() ->
 publish_qos1_test(Config) ->
     Connect = mqtt5_v4compat:gen_connect("pub-qos1-test", [{keepalive, 60}], Config),
     Connack = mqtt5_v4compat:gen_connack(success, Config),
-    Publish = mqtt5_v4compat:gen_publish("pub/qos1/test", 1, <<"message">>,
-                                         [{mid, 19}], Config),
+    Publish = mqtt5_v4compat:gen_publish(
+        "pub/qos1/test",
+        1,
+        <<"message">>,
+        [{mid, 19}],
+        Config
+    ),
     Puback = mqtt5_v4compat:gen_puback(19, Config),
     {ok, Socket} = mqtt5_v4compat:do_client_connect(Connect, Connack, [], Config),
     enable_on_publish(),
@@ -138,8 +156,13 @@ publish_qos1_test(Config) ->
 publish_qos2_test(Config) ->
     Connect = mqtt5_v4compat:gen_connect("pub-qos2-test", [{keepalive, 60}], Config),
     Connack = mqtt5_v4compat:gen_connack(success, Config),
-    Publish = mqtt5_v4compat:gen_publish("pub/qos2/test", 2, <<"message">>,
-                                 [{mid, 312}], Config),
+    Publish = mqtt5_v4compat:gen_publish(
+        "pub/qos2/test",
+        2,
+        <<"message">>,
+        [{mid, 312}],
+        Config
+    ),
     Pubrec = mqtt5_v4compat:gen_pubrec(312, Config),
     Pubrel = mqtt5_v4compat:gen_pubrel(312, Config),
     Pubcomp = mqtt5_v4compat:gen_pubcomp(312, Config),
@@ -169,8 +192,13 @@ publish_b2c_qos2_duplicate_test(Cfg) ->
     Topic = vmq_cth:utopic(Cfg),
     ConnectPub = mqtt5_v4compat:gen_connect(PubId, [], Cfg),
     Connack = mqtt5_v4compat:gen_connack(success, Cfg),
-    Publish = mqtt5_v4compat:gen_publish(Topic, 2, <<"message">>,
-                                         [{mid, 312}], Cfg),
+    Publish = mqtt5_v4compat:gen_publish(
+        Topic,
+        2,
+        <<"message">>,
+        [{mid, 312}],
+        Cfg
+    ),
     Pubrec = mqtt5_v4compat:gen_pubrec(312, Cfg),
     Pubrel = mqtt5_v4compat:gen_pubrel(312, Cfg),
     Pubcomp = mqtt5_v4compat:gen_pubcomp(312, Cfg),
@@ -181,7 +209,6 @@ publish_b2c_qos2_duplicate_test(Cfg) ->
     Suback = mqtt5_v4compat:gen_suback(3265, 2, Cfg),
     ConnectSub = mqtt5_v4compat:gen_connect(SubId, [], Cfg),
     {ok, SubSocket} = mqtt5_v4compat:do_client_connect(ConnectSub, Connack, [], Cfg),
-
 
     enable_on_publish(),
     enable_on_subscribe(),
@@ -204,7 +231,7 @@ publish_b2c_qos2_duplicate_test(Cfg) ->
     %% the duplicate.
     ExpectF =
         fun(Name, What) ->
-                mqtt5_v4compat:expect_packet(SubSocket, Name, What, Cfg)
+            mqtt5_v4compat:expect_packet(SubSocket, Name, What, Cfg)
         end,
 
     RecvPublish = mqtt5_v4compat:gen_publish(Topic, 2, <<"message">>, [{mid, 1}], Cfg),
@@ -226,10 +253,20 @@ publish_c2b_qos2_duplicate_test(Cfg) ->
     Topic = vmq_cth:utopic(Cfg),
     ConnectPub = mqtt5_v4compat:gen_connect(PubId, [], Cfg),
     Connack = mqtt5_v4compat:gen_connack(success, Cfg),
-    Publish = mqtt5_v4compat:gen_publish(Topic, 2, <<"message">>,
-                                 [{mid, 312}], Cfg),
-    PublishDup = mqtt5_v4compat:gen_publish(Topic, 2, <<"message">>,
-                                 [{mid, 312}], Cfg),
+    Publish = mqtt5_v4compat:gen_publish(
+        Topic,
+        2,
+        <<"message">>,
+        [{mid, 312}],
+        Cfg
+    ),
+    PublishDup = mqtt5_v4compat:gen_publish(
+        Topic,
+        2,
+        <<"message">>,
+        [{mid, 312}],
+        Cfg
+    ),
     Pubrec = mqtt5_v4compat:gen_pubrec(312, Cfg),
     Pubrel = mqtt5_v4compat:gen_pubrel(312, Cfg),
     Pubcomp = mqtt5_v4compat:gen_pubcomp(312, Cfg),
@@ -241,7 +278,6 @@ publish_c2b_qos2_duplicate_test(Cfg) ->
     RecvPublish = mqtt5_v4compat:gen_publish(Topic, 0, <<"message">>, [], Cfg),
     ConnectSub = mqtt5_v4compat:gen_connect(SubId, [], Cfg),
     {ok, SubSocket} = mqtt5_v4compat:do_client_connect(ConnectSub, Connack, [], Cfg),
-
 
     enable_on_publish(),
     enable_on_subscribe(),
@@ -272,20 +308,37 @@ publish_c2b_qos2_duplicate_test(Cfg) ->
 
 publish_b2c_disconnect_qos1_test(Config) ->
     ClientId = vmq_cth:ustr(Config) ++ "pub-qos1-disco-test",
-    Connect = mqtt5_v4compat:gen_connect(ClientId,
-                                         [{keepalive, 60}, {clean_session, false}], Config),
+    Connect = mqtt5_v4compat:gen_connect(
+        ClientId,
+        [{keepalive, 60}, {clean_session, false}],
+        Config
+    ),
     Connack1 = mqtt5_v4compat:gen_connack(success, Config),
     Connack2 = mqtt5_v4compat:gen_connack(true, success, Config),
     Subscribe = mqtt5_v4compat:gen_subscribe(3265, "qos1/disconnect/test", 1, Config),
     Suback = mqtt5_v4compat:gen_suback(3265, 1, Config),
-    Publish = mqtt5_v4compat:gen_publish("qos1/disconnect/test", 1,
-                                         <<"disconnect-message">>, [{mid, 1}], Config),
-    PublishDup = mqtt5_v4compat:gen_publish("qos1/disconnect/test", 1,
-                                            <<"disconnect-message">>,
-                                            [{mid, 1}, {dup, true}], Config),
+    Publish = mqtt5_v4compat:gen_publish(
+        "qos1/disconnect/test",
+        1,
+        <<"disconnect-message">>,
+        [{mid, 1}],
+        Config
+    ),
+    PublishDup = mqtt5_v4compat:gen_publish(
+        "qos1/disconnect/test",
+        1,
+        <<"disconnect-message">>,
+        [{mid, 1}, {dup, true}],
+        Config
+    ),
     Puback = mqtt5_v4compat:gen_puback(1, Config),
-    Publish2 = mqtt5_v4compat:gen_publish("qos1/outgoing", 1,
-                                  <<"outgoing-message">>, [{mid, 3266}], Config),
+    Publish2 = mqtt5_v4compat:gen_publish(
+        "qos1/outgoing",
+        1,
+        <<"outgoing-message">>,
+        [{mid, 3266}],
+        Config
+    ),
     Puback2 = packet:gen_puback(3266),
 
     enable_on_publish(),
@@ -315,22 +368,39 @@ publish_b2c_disconnect_qos1_test(Config) ->
 
 publish_b2c_disconnect_qos2_test(Config) ->
     ClientId = vmq_cth:ustr(Config) ++ "pub-b2c-qos2-disco-test",
-    Connect = mqtt5_v4compat:gen_connect(ClientId,
-                                 [{keepalive, 60}, {clean_session, false}], Config),
+    Connect = mqtt5_v4compat:gen_connect(
+        ClientId,
+        [{keepalive, 60}, {clean_session, false}],
+        Config
+    ),
     Connack1 = mqtt5_v4compat:gen_connack(success, Config),
     Connack2 = mqtt5_v4compat:gen_connack(true, success, Config),
     Subscribe = mqtt5_v4compat:gen_subscribe(3265, "qos2/disconnect/test", 2, Config),
     Suback = mqtt5_v4compat:gen_suback(3265, 2, Config),
-    Publish = mqtt5_v4compat:gen_publish("qos2/disconnect/test", 2,
-                                 <<"disconnect-message">>, [{mid, 1}], Config),
-    PublishDup = mqtt5_v4compat:gen_publish("qos2/disconnect/test", 2,
-                                    <<"disconnect-message">>,
-                                    [{mid, 1}, {dup, true}], Config),
+    Publish = mqtt5_v4compat:gen_publish(
+        "qos2/disconnect/test",
+        2,
+        <<"disconnect-message">>,
+        [{mid, 1}],
+        Config
+    ),
+    PublishDup = mqtt5_v4compat:gen_publish(
+        "qos2/disconnect/test",
+        2,
+        <<"disconnect-message">>,
+        [{mid, 1}, {dup, true}],
+        Config
+    ),
     Pubrel = mqtt5_v4compat:gen_pubrel(1, Config),
     Pubrec = mqtt5_v4compat:gen_pubrec(1, Config),
     Pubcomp = mqtt5_v4compat:gen_pubcomp(1, Config),
-    Publish2 = mqtt5_v4compat:gen_publish("qos1/outgoing", 1,
-                                  <<"outgoing-message">>, [{mid, 3266}], Config),
+    Publish2 = mqtt5_v4compat:gen_publish(
+        "qos1/outgoing",
+        1,
+        <<"outgoing-message">>,
+        [{mid, 3266}],
+        Config
+    ),
     enable_on_publish(),
     enable_on_subscribe(),
     {ok, Socket} = mqtt5_v4compat:do_client_connect(Connect, Connack1, [], Config),
@@ -365,11 +435,18 @@ publish_b2c_retry_qos1_test(Config) ->
     Connack = packet:gen_connack(0),
     Subscribe = packet:gen_subscribe(3265, "qos1/timeout/test", 1),
     Suback = packet:gen_suback(3265, 1),
-    Publish = packet:gen_publish("qos1/timeout/test", 1,
-                                 <<"timeout-message">>, [{mid, 1}]),
-    PublishDup = packet:gen_publish("qos1/timeout/test", 1,
-                                    <<"timeout-message">>,
-                                    [{mid, 1}, {dup, true}]),
+    Publish = packet:gen_publish(
+        "qos1/timeout/test",
+        1,
+        <<"timeout-message">>,
+        [{mid, 1}]
+    ),
+    PublishDup = packet:gen_publish(
+        "qos1/timeout/test",
+        1,
+        <<"timeout-message">>,
+        [{mid, 1}, {dup, true}]
+    ),
     Puback = packet:gen_puback(1),
     enable_on_publish(),
     enable_on_subscribe(),
@@ -393,11 +470,18 @@ publish_b2c_retry_qos2_test(Config) ->
     Connack = packet:gen_connack(0),
     Subscribe = packet:gen_subscribe(3265, "qos2/timeout/test", 2),
     Suback = packet:gen_suback(3265, 2),
-    Publish = packet:gen_publish("qos2/timeout/test", 2,
-                                 <<"timeout-message">>, [{mid, 1}]),
-    PublishDup = packet:gen_publish("qos2/timeout/test", 2,
-                                    <<"timeout-message">>,
-                                    [{mid, 1}, {dup, true}]),
+    Publish = packet:gen_publish(
+        "qos2/timeout/test",
+        2,
+        <<"timeout-message">>,
+        [{mid, 1}]
+    ),
+    PublishDup = packet:gen_publish(
+        "qos2/timeout/test",
+        2,
+        <<"timeout-message">>,
+        [{mid, 1}, {dup, true}]
+    ),
     Pubrec = packet:gen_pubrec(1),
     Pubrel = packet:gen_pubrel(1),
     Pubcomp = packet:gen_pubcomp(1),
@@ -424,15 +508,27 @@ publish_b2c_retry_qos2_test(Config) ->
 
 publish_c2b_disconnect_qos2_test(Config) ->
     ClientId = vmq_cth:ustr(Config) ++ "pub-c2b-qos2-disco-test",
-    Connect = mqtt5_v4compat:gen_connect(ClientId,
-                                         [{keepalive, 60}, {clean_session, false}], Config),
+    Connect = mqtt5_v4compat:gen_connect(
+        ClientId,
+        [{keepalive, 60}, {clean_session, false}],
+        Config
+    ),
     Connack1 = mqtt5_v4compat:gen_connack(success, Config),
     Connack2 = mqtt5_v4compat:gen_connack(true, success, Config),
-    Publish = mqtt5_v4compat:gen_publish("qos2/disconnect/test", 2,
-                                         <<"disconnect-message">>, [{mid, 1}], Config),
-    PublishDup = mqtt5_v4compat:gen_publish("qos2/disconnect/test", 2,
-                                            <<"disconnect-message">>,
-                                            [{mid, 1}, {dup, true}], Config),
+    Publish = mqtt5_v4compat:gen_publish(
+        "qos2/disconnect/test",
+        2,
+        <<"disconnect-message">>,
+        [{mid, 1}],
+        Config
+    ),
+    PublishDup = mqtt5_v4compat:gen_publish(
+        "qos2/disconnect/test",
+        2,
+        <<"disconnect-message">>,
+        [{mid, 1}, {dup, true}],
+        Config
+    ),
     Pubrec = mqtt5_v4compat:gen_pubrec(1, Config),
     Pubrel = mqtt5_v4compat:gen_pubrel(1, Config),
     Pubcomp = mqtt5_v4compat:gen_pubcomp(1, Config),
@@ -454,10 +550,10 @@ publish_c2b_disconnect_qos2_test(Config) ->
     {ok, Socket2} = mqtt5_v4compat:do_client_connect(Connect, Connack2, [], Config),
     ok = gen_tcp:send(Socket2, Pubrel),
     Pubcomp2 =
-    case mqtt5_v4compat:protover(Config) of
-        5 -> packetv5:gen_pubcomp(1, ?M5_PACKET_ID_NOT_FOUND, #{});
-        _ -> Pubcomp
-    end,
+        case mqtt5_v4compat:protover(Config) of
+            5 -> packetv5:gen_pubcomp(1, ?M5_PACKET_ID_NOT_FOUND, #{});
+            _ -> Pubcomp
+        end,
     ok = mqtt5_v4compat:expect_packet(Socket2, "pubcomp", Pubcomp2, Config),
     disable_on_publish(),
     ok = expect_alive(Socket2),
@@ -466,8 +562,12 @@ publish_c2b_disconnect_qos2_test(Config) ->
 publish_c2b_retry_qos2_test(_Config) ->
     Connect = packet:gen_connect("pub-c2b-qos2-timeout-test", [{keepalive, 60}]),
     Connack = packet:gen_connack(0),
-    Publish = packet:gen_publish("pub/qos2/test", 2,
-                                 <<"timeout-message">>, [{mid, 1926}]),
+    Publish = packet:gen_publish(
+        "pub/qos2/test",
+        2,
+        <<"timeout-message">>,
+        [{mid, 1926}]
+    ),
     Pubrec = packet:gen_pubrec(1926),
     Pubrel = packet:gen_pubrel(1926),
     Pubcomp = packet:gen_pubcomp(1926),
@@ -488,10 +588,14 @@ publish_b2c_ensure_valid_msg_ids_test(Config) ->
     enable_on_subscribe(),
     ClientId = vmq_cth:ustr(Config) ++ "-persisted",
     Topic = vmq_cth:utopic(Config) ++ "/client",
-    Connect = mqtt5_v4compat:gen_connect(ClientId,
-                                         [{keepalive, 60},
-                                          {clean_session, false}],
-                                         Config),
+    Connect = mqtt5_v4compat:gen_connect(
+        ClientId,
+        [
+            {keepalive, 60},
+            {clean_session, false}
+        ],
+        Config
+    ),
     Connack = mqtt5_v4compat:gen_connack(success, Config),
     {ok, Socket} = mqtt5_v4compat:do_client_connect(Connect, Connack, [], Config),
     %% subscribe to the offline topic
@@ -502,10 +606,14 @@ publish_b2c_ensure_valid_msg_ids_test(Config) ->
 
     %% connect publisher
     PubClientId = vmq_cth:ustr(Config) ++ "-publisher",
-    PubConnect = mqtt5_v4compat:gen_connect(PubClientId,
-                                            [{keepalive, 60},
-                                             {clean_session, true}],
-                                            Config),
+    PubConnect = mqtt5_v4compat:gen_connect(
+        PubClientId,
+        [
+            {keepalive, 60},
+            {clean_session, true}
+        ],
+        Config
+    ),
     {ok, PubSocket} = mqtt5_v4compat:do_client_connect(PubConnect, Connack, [], Config),
     Publish1 = mqtt5_v4compat:gen_publish(Topic, 2, <<"msg1">>, [{mid, 1}], Config),
     Pubrec1 = mqtt5_v4compat:gen_pubrec(1, Config),
@@ -561,7 +669,6 @@ publish_b2c_ensure_valid_msg_ids_test(Config) ->
     ok = gen_tcp:send(Socket1, Disconnect),
     ok = gen_tcp:close(Socket1).
 
-
 pattern_matching_test(Config) ->
     ok = pattern_test("#", "test/topic", Config),
     ok = pattern_test("#", "/test/topic", Config),
@@ -574,8 +681,11 @@ pattern_matching_test(Config) ->
     ok = pattern_test("/#", "/foo", Config),
     ok = pattern_test("test/topic/", "test/topic/", Config),
     ok = pattern_test("test/topic/+", "test/topic/", Config),
-    ok = pattern_test("+/+/+/+/+/+/+/+/+/+/test",
-                      "one/two/three/four/five/six/seven/eight/nine/ten/test", Config),
+    ok = pattern_test(
+        "+/+/+/+/+/+/+/+/+/+/test",
+        "one/two/three/four/five/six/seven/eight/nine/ten/test",
+        Config
+    ),
     ok = pattern_test("#", "test////a//topic", Config),
     ok = pattern_test("#", "/test////a//topic", Config),
     ok = pattern_test("foo/#", "foo//bar///baz", Config),
@@ -592,13 +702,19 @@ pattern_test(SubTopic, PubTopic, Config) ->
     case vmq_topic:contains_wildcard(CT) of
         true ->
             vmq_reg_redis_trie:add_complex_topics([CT]);
-        _ -> ok
+        _ ->
+            ok
     end,
     Connect = mqtt5_v4compat:gen_connect("pattern-sub-test", [{keepalive, 60}], Config),
     Connack = mqtt5_v4compat:gen_connack(success, Config),
     Publish = mqtt5_v4compat:gen_publish(PubTopic, 0, <<"message">>, [], Config),
-    PublishRetained = mqtt5_v4compat:gen_publish(PubTopic, 0, <<"message">>,
-                                         [{retain, true}], Config),
+    PublishRetained = mqtt5_v4compat:gen_publish(
+        PubTopic,
+        0,
+        <<"message">>,
+        [{retain, true}],
+        Config
+    ),
     Subscribe = mqtt5_v4compat:gen_subscribe(312, SubTopic, 0, Config),
     Suback = mqtt5_v4compat:gen_suback(312, 0, Config),
     Unsubscribe = mqtt5_v4compat:gen_unsubscribe(234, SubTopic, Config),
@@ -660,8 +776,10 @@ not_allowed_publish_close_qos2_mqtt_3_1(_) ->
     gen_tcp:close(Socket).
 
 not_allowed_publish_close_qos0_mqtt_3_1_1(_) ->
-    Connect = packet:gen_connect("pattern-sub-test", [{keepalive, 60},
-                                                      {proto_ver, 4}]),
+    Connect = packet:gen_connect("pattern-sub-test", [
+        {keepalive, 60},
+        {proto_ver, 4}
+    ]),
     Connack = packet:gen_connack(0),
     Topic = "test/topic/not_allowed",
     Publish = packet:gen_publish(Topic, 0, <<"message">>, []),
@@ -671,8 +789,10 @@ not_allowed_publish_close_qos0_mqtt_3_1_1(_) ->
     {error, closed} = gen_tcp:recv(Socket, 0, 1000).
 
 not_allowed_publish_close_qos1_mqtt_3_1_1(_) ->
-    Connect = packet:gen_connect("pattern-sub-test", [{keepalive, 60},
-                                                      {proto_ver, 4}]),
+    Connect = packet:gen_connect("pattern-sub-test", [
+        {keepalive, 60},
+        {proto_ver, 4}
+    ]),
     Connack = packet:gen_connack(0),
     Topic = "test/topic/not_allowed",
     Publish = packet:gen_publish(Topic, 1, <<"message">>, [{mid, 1}]),
@@ -682,8 +802,10 @@ not_allowed_publish_close_qos1_mqtt_3_1_1(_) ->
     {error, closed} = gen_tcp:recv(Socket, 0, 1000).
 
 not_allowed_publish_close_qos2_mqtt_3_1_1(_) ->
-    Connect = packet:gen_connect("pattern-sub-test", [{keepalive, 60},
-                                                      {proto_ver, 4}]),
+    Connect = packet:gen_connect("pattern-sub-test", [
+        {keepalive, 60},
+        {proto_ver, 4}
+    ]),
     Connack = packet:gen_connack(0),
     Topic = "test/topic/not_allowed",
     Publish = packet:gen_publish(Topic, 2, <<"message">>, [{mid, 1}]),
@@ -691,7 +813,6 @@ not_allowed_publish_close_qos2_mqtt_3_1_1(_) ->
     {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
     gen_tcp:send(Socket, Publish),
     {error, closed} = gen_tcp:recv(Socket, 0, 1000).
-
 
 drop_dollar_topic_publish(Config) ->
     Connect = mqtt5_v4compat:gen_connect("drop-dollar-test", [{keepalive, 60}], Config),
@@ -705,8 +826,10 @@ drop_dollar_topic_publish(Config) ->
     {error, timeout} = gen_tcp:recv(Socket, 0, 1000).
 
 not_allowed_publish_qos0_mqtt_5(_) ->
-    Connect = packetv5:gen_connect("pattern-sub-test", [{keepalive, 60},
-                                                      {clean_start, true}]),
+    Connect = packetv5:gen_connect("pattern-sub-test", [
+        {keepalive, 60},
+        {clean_start, true}
+    ]),
     Connack = packetv5:gen_connack(),
     Topic = "test/topic/not_allowed",
     Publish = packetv5:gen_publish(Topic, 0, <<"message">>, [{mid, 1}]),
@@ -718,8 +841,10 @@ not_allowed_publish_qos0_mqtt_5(_) ->
     ok = gen_tcp:close(Socket).
 
 not_allowed_publish_qos1_mqtt_5(_) ->
-    Connect = packetv5:gen_connect("pattern-sub-test", [{keepalive, 60},
-                                                      {clean_start, true}]),
+    Connect = packetv5:gen_connect("pattern-sub-test", [
+        {keepalive, 60},
+        {clean_start, true}
+    ]),
     Connack = packetv5:gen_connack(),
     Topic = "test/topic/not_allowed",
     Publish = packetv5:gen_publish(Topic, 1, <<"message">>, [{mid, 1}]),
@@ -731,8 +856,10 @@ not_allowed_publish_qos1_mqtt_5(_) ->
     ok = gen_tcp:close(Socket).
 
 not_allowed_publish_qos2_mqtt_5(_) ->
-    Connect = packetv5:gen_connect("pattern-sub-test", [{keepalive, 60},
-                                                        {clean_start, true}]),
+    Connect = packetv5:gen_connect("pattern-sub-test", [
+        {keepalive, 60},
+        {clean_start, true}
+    ]),
     Connack = packetv5:gen_connack(),
     Topic = "test/topic/not_allowed",
     Publish = packetv5:gen_publish(Topic, 2, <<"message">>, [{mid, 1}]),
@@ -749,18 +876,33 @@ message_size_exceeded_close(_) ->
     vmq_metrics:reset_counters(),
     Connect = packet:gen_connect("pub-excessive-test", [{keepalive, 60}]),
     Connack = packet:gen_connack(0),
-    Publish = packet:gen_publish("pub/excessive/test", 0, vmq_test_utils:rand_bytes(1024),
-                                 [{mid, 19}]),
+    Publish = packet:gen_publish(
+        "pub/excessive/test",
+        0,
+        vmq_test_utils:rand_bytes(1024),
+        [{mid, 19}]
+    ),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
     enable_on_publish(),
     ok = gen_tcp:send(Socket, Publish),
     {error, closed} = gen_tcp:recv(Socket, 0, 1000),
     true = lists:any(
-             fun({#metric_def{
-                     type = counter,
-                     name = mqtt_invalid_msg_size_error}, 1}) -> true;
-                (_) -> false
-             end,vmq_metrics:metrics(#{aggregate => false})),
+        fun
+            (
+                {
+                    #metric_def{
+                        type = counter,
+                        name = mqtt_invalid_msg_size_error
+                    },
+                    1
+                }
+            ) ->
+                true;
+            (_) ->
+                false
+        end,
+        vmq_metrics:metrics(#{aggregate => false})
+    ),
     vmq_config:set_env(max_message_size, OldLimit, false),
     disable_on_publish().
 
@@ -771,9 +913,14 @@ shared_subscription_offline(Cfg) ->
     Prefix = vmq_cth:ustr(Cfg),
     PubConnect = mqtt5_v4compat:gen_connect(Prefix ++ "single-offline-pub", [{keepalive, 60}], Cfg),
     SubOfflineClientId = Prefix ++ "single-offline-sha-sub",
-    SubConnectOffline = mqtt5_v4compat:gen_connect(SubOfflineClientId,
-                                                   [{keepalive, 60},
-                                                    {clean_session, false}], Cfg),
+    SubConnectOffline = mqtt5_v4compat:gen_connect(
+        SubOfflineClientId,
+        [
+            {keepalive, 60},
+            {clean_session, false}
+        ],
+        Cfg
+    ),
     Topic = "shared_sub_topic_offline",
     Subscription = "$share/" ++ Prefix ++ "/" ++ Topic,
     {ok, PubSocket} = mqtt5_v4compat:do_client_connect(PubConnect, Connack, [], Cfg),
@@ -788,24 +935,33 @@ shared_subscription_offline(Cfg) ->
     %% wait for the client to be offline before publishing
     wait_for_offline_event(SubOfflineClientId, 500),
 
-    PubFun
-        = fun(Socket, Mid) ->
-                  Publish = mqtt5_v4compat:gen_publish(Topic, 1,
-                                                       <<Mid:8, (vmq_test_utils:rand_bytes(10))/binary>>,
-                                                       [{mid, Mid}], Cfg),
-                  Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
-                  ok = gen_tcp:send(Socket, Publish),
-                  ok = mqtt5_v4compat:expect_packet(Socket, "puback", Puback, Cfg),
-                  {Mid, Publish}
-          end,
-    Published = [PubFun(PubSocket, Mid) || Mid <- lists:seq(1,10)],
+    PubFun =
+        fun(Socket, Mid) ->
+            Publish = mqtt5_v4compat:gen_publish(
+                Topic,
+                1,
+                <<Mid:8, (vmq_test_utils:rand_bytes(10))/binary>>,
+                [{mid, Mid}],
+                Cfg
+            ),
+            Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
+            ok = gen_tcp:send(Socket, Publish),
+            ok = mqtt5_v4compat:expect_packet(Socket, "puback", Puback, Cfg),
+            {Mid, Publish}
+        end,
+    Published = [PubFun(PubSocket, Mid) || Mid <- lists:seq(1, 10)],
     ConnackSP = mqtt5_v4compat:gen_connack(true, success, Cfg),
-    {ok, SubSocketOffline2} = mqtt5_v4compat:do_client_connect(SubConnectOffline, ConnackSP, [], Cfg),
-    [begin
-         ok = mqtt5_v4compat:expect_packet(SubSocketOffline2, "publish", Expect, Cfg),
-         Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
-         ok = gen_tcp:send(SubSocketOffline2, Puback)
-     end || {Mid, Expect} <- Published ],
+    {ok, SubSocketOffline2} = mqtt5_v4compat:do_client_connect(
+        SubConnectOffline, ConnackSP, [], Cfg
+    ),
+    [
+        begin
+            ok = mqtt5_v4compat:expect_packet(SubSocketOffline2, "publish", Expect, Cfg),
+            Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
+            ok = gen_tcp:send(SubSocketOffline2, Puback)
+        end
+     || {Mid, Expect} <- Published
+    ],
     disable_on_publish(),
     disable_on_subscribe().
 
@@ -815,14 +971,23 @@ shared_subscription_online_first(Cfg) ->
     Connack = mqtt5_v4compat:gen_connack(success, Cfg),
     Prefix = vmq_cth:ustr(Cfg),
     PubConnect = mqtt5_v4compat:gen_connect(Prefix ++ "shared-sub-pub", [{keepalive, 60}], Cfg),
-    SubConnectOnline = mqtt5_v4compat:gen_connect(Prefix ++ "shared-sub-sub-online",
-                                                  [{keepalive, 60},
-                                                   {clean_session, false}], Cfg),
+    SubConnectOnline = mqtt5_v4compat:gen_connect(
+        Prefix ++ "shared-sub-sub-online",
+        [
+            {keepalive, 60},
+            {clean_session, false}
+        ],
+        Cfg
+    ),
     SubOfflineClientId = Prefix ++ "shared-sub-sub-offline",
-    SubConnectOffline = mqtt5_v4compat:gen_connect(SubOfflineClientId,
-                                                   [{keepalive, 60},
-                                                    {clean_session, false}],
-                                                   Cfg),
+    SubConnectOffline = mqtt5_v4compat:gen_connect(
+        SubOfflineClientId,
+        [
+            {keepalive, 60},
+            {clean_session, false}
+        ],
+        Cfg
+    ),
     Topic = "shared_sub_topic_online_first",
     Subscription = "$share/" ++ Prefix ++ "/" ++ Topic,
     {ok, PubSocket} = mqtt5_v4compat:do_client_connect(PubConnect, Connack, [], Cfg),
@@ -841,24 +1006,31 @@ shared_subscription_online_first(Cfg) ->
     wait_for_offline_event(SubOfflineClientId, 500),
 
     %% now let's publish
-    PubFun
-        = fun(Socket, Mid) ->
-                  Publish = mqtt5_v4compat:gen_publish(Topic, 1,
-                                                       <<Mid:8, (vmq_test_utils:rand_bytes(10))/binary>>,
-                                               [{mid, Mid}], Cfg),
-                  Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
-                  ok = gen_tcp:send(Socket, Publish),
-                  ok = mqtt5_v4compat:expect_packet(Socket, "puback", Puback, Cfg),
-                  {Mid, Publish}
-          end,
-    Published = [PubFun(PubSocket, Mid) || Mid <- lists:seq(1,10)],
+    PubFun =
+        fun(Socket, Mid) ->
+            Publish = mqtt5_v4compat:gen_publish(
+                Topic,
+                1,
+                <<Mid:8, (vmq_test_utils:rand_bytes(10))/binary>>,
+                [{mid, Mid}],
+                Cfg
+            ),
+            Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
+            ok = gen_tcp:send(Socket, Publish),
+            ok = mqtt5_v4compat:expect_packet(Socket, "puback", Puback, Cfg),
+            {Mid, Publish}
+        end,
+    Published = [PubFun(PubSocket, Mid) || Mid <- lists:seq(1, 10)],
     %% since all messages should end up with the online subscriber, we
     %% can check they arrived one by one in the publish order.
-    [begin
-         ok = mqtt5_v4compat:expect_packet(SubSocketOnline, "publish", Expect, Cfg),
-         Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
-         ok = gen_tcp:send(SubSocketOnline, Puback)
-     end || {Mid, Expect} <- Published ],
+    [
+        begin
+            ok = mqtt5_v4compat:expect_packet(SubSocketOnline, "publish", Expect, Cfg),
+            Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
+            ok = gen_tcp:send(SubSocketOnline, Puback)
+        end
+     || {Mid, Expect} <- Published
+    ],
     disable_on_publish(),
     disable_on_subscribe().
 
@@ -868,12 +1040,22 @@ shared_subscription_does_not_honor_grouping(Cfg) ->
     Connack = mqtt5_v4compat:gen_connack(success, Cfg),
     Prefix = vmq_cth:ustr(Cfg),
     PubConnect = mqtt5_v4compat:gen_connect(Prefix ++ "shared-sub-pub", [{keepalive, 60}], Cfg),
-    SubConnectOnline1 = mqtt5_v4compat:gen_connect(Prefix ++ "shared-sub-sub-online-1",
-                                                  [{keepalive, 60},
-                                                   {clean_session, false}], Cfg),
-    SubConnectOnline2 = mqtt5_v4compat:gen_connect(Prefix ++ "shared-sub-sub-online-2",
-                                                  [{keepalive, 60},
-                                                   {clean_session, false}], Cfg),
+    SubConnectOnline1 = mqtt5_v4compat:gen_connect(
+        Prefix ++ "shared-sub-sub-online-1",
+        [
+            {keepalive, 60},
+            {clean_session, false}
+        ],
+        Cfg
+    ),
+    SubConnectOnline2 = mqtt5_v4compat:gen_connect(
+        Prefix ++ "shared-sub-sub-online-2",
+        [
+            {keepalive, 60},
+            {clean_session, false}
+        ],
+        Cfg
+    ),
     Topic = "shared_sub_grouping_topic",
     Subscription1 = "$share/" ++ Prefix ++ "-1" ++ "/" ++ Topic,
     Subscription2 = "$share/" ++ Prefix ++ "-2" ++ "/" ++ Topic,
@@ -889,46 +1071,37 @@ shared_subscription_does_not_honor_grouping(Cfg) ->
     ok = mqtt5_v4compat:expect_packet(SubSocket2, "suback", Suback, Cfg),
 
     %% now let's publish
-    PubFun
-        = fun(Socket, Mid) ->
-                  Publish = mqtt5_v4compat:gen_publish(Topic, 1,
-                                                       <<Mid:8, (vmq_test_utils:rand_bytes(10))/binary>>,
-                                               [{mid, Mid}], Cfg),
-                  Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
-                  ok = gen_tcp:send(Socket, Publish),
-                  ok = mqtt5_v4compat:expect_packet(Socket, "puback", Puback, Cfg),
-                  {Mid, Publish}
-          end,
-    _Published = [PubFun(PubSocket, Mid) || Mid <- lists:seq(1,10)],
-    Pid1= spawn(?MODULE, receive_at_most_n_frames, [self(), SubSocket1, 10, 1, Cfg]),
-    Pid2= spawn(?MODULE, receive_at_most_n_frames, [self(), SubSocket2, 10, 1, Cfg]),
-    ReceivedF1 = receive
-                    {Pid1, Res} -> Res
-                 after 50000 ->
-                    {error, timeout}
-                 end,
-    ReceivedF2 = receive
-                     {Pid2, Res1} -> Res1
-                 after 50000 -> {error, timeout}
-                 end,
+    PubFun =
+        fun(Socket, Mid) ->
+            Publish = mqtt5_v4compat:gen_publish(
+                Topic,
+                1,
+                <<Mid:8, (vmq_test_utils:rand_bytes(10))/binary>>,
+                [{mid, Mid}],
+                Cfg
+            ),
+            Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
+            ok = gen_tcp:send(Socket, Publish),
+            ok = mqtt5_v4compat:expect_packet(Socket, "puback", Puback, Cfg),
+            Publish
+        end,
+    PublishedPackets = [PubFun(PubSocket, Mid) || Mid <- lists:seq(1, 10)],
+    Pid1 = spawn(?MODULE, receive_at_most_n_frames, [self(), SubSocket1, 10, 1, Cfg]),
+    Pid2 = spawn(?MODULE, receive_at_most_n_frames, [self(), SubSocket2, 10, 1, Cfg]),
+    ReceivedF1 =
+        receive
+            {Pid1, Res1} -> Res1
+        after 50000 ->
+            {error, timeout}
+        end,
+    ReceivedF2 =
+        receive
+            {Pid2, Res2} -> Res2
+        after 50000 -> {error, timeout}
+        end,
 
     10 = length(ReceivedF1) + length(ReceivedF2),
-
-    %% since all messages should end up amongst the two online subscribers
-    %% (as we internally consider them in same shared subscription group),
-    %% we can check they arrived one by one in the publish order amongst them.
-%%    [begin
-%%        Socket = case mqtt5_v4compat:expect_packet(SubSocket1, "publish", Expect, Cfg) of
-%%             ok ->
-%%               SubSocket1;
-%%             {error, _} ->
-%%               ok = mqtt5_v4compat:expect_packet(SubSocket2, "publish", Expect, Cfg),
-%%               SubSocket2
-%%        end,
-%%
-%%        Puback = mqtt5_v4compat:gen_puback(Mid, Cfg),
-%%        ok = gen_tcp:send(Socket, Puback)
-%%     end || {Mid, Expect} <- Published ],
+    compare_published_packets_payload(PublishedPackets, ReceivedF1, ReceivedF2),
 
     disable_on_publish(),
     disable_on_subscribe().
@@ -948,9 +1121,11 @@ message_expiry_interval(_) ->
     enable_on_message_drop(),
 
     %% set up subscriber
-    SubConnect = packetv5:gen_connect("message-expiry-sub", [{keepalive, 60},
-                                                             {clean_start, false},
-                                                             {properties, #{p_session_expiry_interval => 16#FFFFFFFF}}]),
+    SubConnect = packetv5:gen_connect("message-expiry-sub", [
+        {keepalive, 60},
+        {clean_start, false},
+        {properties, #{p_session_expiry_interval => 16#FFFFFFFF}}
+    ]),
     Connack = packetv5:gen_connack(?M5_CONNACK_ACCEPT),
     {ok, SubSocket} = packetv5:do_client_connect(SubConnect, Connack, []),
     SubTopic60s = packetv5:gen_subtopic(<<"message/expiry/60s">>, 1),
@@ -958,7 +1133,7 @@ message_expiry_interval(_) ->
     SubscribeAll = packetv5:gen_subscribe(10, [SubTopic60s, SubTopic1s], #{}),
     ok = gen_tcp:send(SubSocket, SubscribeAll),
 
-    SubAck = packetv5:gen_suback(10, [1,1], #{}),
+    SubAck = packetv5:gen_suback(10, [1, 1], #{}),
     ok = packetv5:expect_frame(SubSocket, SubAck),
     Disconnect = packetv5:gen_disconnect(),
     ok = gen_tcp:send(SubSocket, Disconnect),
@@ -970,15 +1145,23 @@ message_expiry_interval(_) ->
 
     %% Publish some messages
     Expiry60s = #{p_message_expiry_interval => 60},
-    PE60s = packetv5:gen_publish(<<"message/expiry/60s">>, 1, <<"e60s">>,
-                                 [{properties, Expiry60s}, {mid, 0}]),
+    PE60s = packetv5:gen_publish(
+        <<"message/expiry/60s">>,
+        1,
+        <<"e60s">>,
+        [{properties, Expiry60s}, {mid, 0}]
+    ),
     ok = gen_tcp:send(PubSocket, PE60s),
     Puback0 = packetv5:gen_puback(0),
     ok = packetv5:expect_frame(PubSocket, Puback0),
 
     Expiry1s = #{p_message_expiry_interval => 1},
-    PE1s = packetv5:gen_publish(<<"message/expiry/1s">>, 1, <<"e1s">>,
-                                [{properties, Expiry1s}, {mid, 1}]),
+    PE1s = packetv5:gen_publish(
+        <<"message/expiry/1s">>,
+        1,
+        <<"e1s">>,
+        [{properties, Expiry1s}, {mid, 1}]
+    ),
     ok = gen_tcp:send(PubSocket, PE1s),
     Puback1 = packetv5:gen_puback(1),
     ok = packetv5:expect_frame(PubSocket, Puback1),
@@ -994,9 +1177,11 @@ message_expiry_interval(_) ->
 
     %% receive the message with a long expiry interval
     {ok, RPE60s, <<>>} = packetv5:receive_frame(SubSocket1),
-    #mqtt5_publish{topic = [<<"message">>, <<"expiry">>, <<"60s">>],
-                   qos = 1,
-                   properties = #{p_message_expiry_interval := Remaining}} = RPE60s,
+    #mqtt5_publish{
+        topic = [<<"message">>, <<"expiry">>, <<"60s">>],
+        qos = 1,
+        properties = #{p_message_expiry_interval := Remaining}
+    } = RPE60s,
     true = Remaining < 60,
 
     %% The 1s message shouldn't arrive, but let's just block a bit to
@@ -1023,7 +1208,7 @@ publish_c2b_topic_alias(_Config) ->
     SubConnect = packetv5:gen_connect("publish-c2b-topic-alias-subscriber", [{keepalive, 60}]),
     SubConnack = packetv5:gen_connack(0, ?M5_CONNACK_ACCEPT, #{p_topic_alias_max => 3}),
     {ok, SubSocket} = packetv5:do_client_connect(SubConnect, SubConnack, []),
-    Subscribe = packetv5:gen_subscribe(77, [packetv5:gen_subtopic(Topic,0)], #{}),
+    Subscribe = packetv5:gen_subscribe(77, [packetv5:gen_subtopic(Topic, 0)], #{}),
     ok = gen_tcp:send(SubSocket, Subscribe),
     SubAck = packetv5:gen_suback(77, [0], #{}),
     ok = packetv5:expect_frame(SubSocket, SubAck),
@@ -1033,10 +1218,18 @@ publish_c2b_topic_alias(_Config) ->
     {ok, PubSocket} = packetv5:do_client_connect(PubConnect, PubConnack, []),
 
     TA1 = #{p_topic_alias => 1},
-    TASetup = packetv5:gen_publish(Topic, 0, <<"publish alias setup">>,
-                                   [{properties, TA1}]),
-    TAPub = packetv5:gen_publish(<<>>, 0, <<"publish alias pub">>,
-                                 [{properties, TA1}]),
+    TASetup = packetv5:gen_publish(
+        Topic,
+        0,
+        <<"publish alias setup">>,
+        [{properties, TA1}]
+    ),
+    TAPub = packetv5:gen_publish(
+        <<>>,
+        0,
+        <<"publish alias pub">>,
+        [{properties, TA1}]
+    ),
 
     ok = gen_tcp:send(PubSocket, TASetup),
     ok = gen_tcp:send(PubSocket, TAPub),
@@ -1063,11 +1256,13 @@ publish_b2c_topic_alias(Config) ->
     PubClientId = vmq_cth:ustr(Config) ++ "-pub",
     Topic = list_to_binary(vmq_cth:utopic(Config)),
 
-    SubConnect = packetv5:gen_connect(SubClientId,
-                                      [{keepalive, 60}, {properties, #{p_topic_alias_max => 3}}]),
+    SubConnect = packetv5:gen_connect(
+        SubClientId,
+        [{keepalive, 60}, {properties, #{p_topic_alias_max => 3}}]
+    ),
     SubConnack = packetv5:gen_connack(0, ?M5_CONNACK_ACCEPT, #{}),
     {ok, SubSocket} = packetv5:do_client_connect(SubConnect, SubConnack, []),
-    Subscribe = packetv5:gen_subscribe(77, [packetv5:gen_subtopic(Topic,0)], #{}),
+    Subscribe = packetv5:gen_subscribe(77, [packetv5:gen_subtopic(Topic, 0)], #{}),
     ok = gen_tcp:send(SubSocket, Subscribe),
     SubAck = packetv5:gen_suback(77, [0], #{}),
     ok = packetv5:expect_frame(SubSocket, SubAck),
@@ -1084,10 +1279,18 @@ publish_b2c_topic_alias(Config) ->
 
     TA1 = #{p_topic_alias => 1},
 
-    ExpectSetupPub = packetv5:gen_publish(Topic, 0, <<"publish alias setup">>,
-                                          [{properties, TA1}]),
-    ExpectTAPub = packetv5:gen_publish(<<>>, 0, <<"publish alias pub">>,
-                                          [{properties, TA1}]),
+    ExpectSetupPub = packetv5:gen_publish(
+        Topic,
+        0,
+        <<"publish alias setup">>,
+        [{properties, TA1}]
+    ),
+    ExpectTAPub = packetv5:gen_publish(
+        <<>>,
+        0,
+        <<"publish alias pub">>,
+        [{properties, TA1}]
+    ),
 
     ok = packetv5:expect_frame(SubSocket, ExpectSetupPub),
     ok = packetv5:expect_frame(SubSocket, ExpectTAPub),
@@ -1100,7 +1303,6 @@ publish_b2c_topic_alias(Config) ->
     ok.
 
 forward_properties(_Config) ->
-
     enable_on_publish(),
     enable_on_subscribe(),
 
@@ -1110,7 +1312,7 @@ forward_properties(_Config) ->
     SubConnect = packetv5:gen_connect("property-passthrough-sub-test", [{keepalive, 60}]),
     SubConnack = packetv5:gen_connack(0, ?M5_CONNACK_ACCEPT, #{}),
     {ok, SubSocket} = packetv5:do_client_connect(SubConnect, SubConnack, []),
-    Subscribe = packetv5:gen_subscribe(77, [packetv5:gen_subtopic(Topic,0)], #{}),
+    Subscribe = packetv5:gen_subscribe(77, [packetv5:gen_subtopic(Topic, 0)], #{}),
     ok = gen_tcp:send(SubSocket, Subscribe),
     SubAck = packetv5:gen_suback(77, [0], #{}),
     ok = packetv5:expect_frame(SubSocket, SubAck),
@@ -1118,49 +1320,60 @@ forward_properties(_Config) ->
     %% setup publisher
     Properties =
         [
-         %% A Server MUST send the Payload Format Indicator unaltered to
-         %% all subscribers receiving the Application Message
-         %% [MQTT-3.3.2-4]
-         #{p_payload_format_indicator => utf8},
-         #{p_payload_format_indicator => unspecified},
+            %% A Server MUST send the Payload Format Indicator unaltered to
+            %% all subscribers receiving the Application Message
+            %% [MQTT-3.3.2-4]
+            #{p_payload_format_indicator => utf8},
+            #{p_payload_format_indicator => unspecified},
 
-         %% The Server MUST send the Response Topic unaltered to all
-         %% subscribers receiving the Application Message
-         %% [MQTT-3.3.2-15].
-         #{p_response_topic => <<"response topic">>},
+            %% The Server MUST send the Response Topic unaltered to all
+            %% subscribers receiving the Application Message
+            %% [MQTT-3.3.2-15].
+            #{p_response_topic => <<"response topic">>},
 
-         %% The Server MUST send the Correlation Data unaltered to all
-         %% subscribers receiving the Application Message
-         %% [MQTT-3.3.2-16].
-         #{p_correlation_data => <<"correlation data">>},
+            %% The Server MUST send the Correlation Data unaltered to all
+            %% subscribers receiving the Application Message
+            %% [MQTT-3.3.2-16].
+            #{p_correlation_data => <<"correlation data">>},
 
-         %% The Server MUST send all User Properties unaltered in a
-         %% PUBLISH packet when forwarding the Application Message to
-         %% a Client [MQTT-3.3.2-17]. The Server MUST maintain the
-         %% order of User Properties when forwarding the Application
-         %% Message [MQTT-3.3.2-18].
-         #{p_user_property => [{<<"k1">>, <<"v1">>},
-                               {<<"k2">>, <<"v2">>},
-                               {<<"k3">>, <<"v3">>},
-                               {<<"k2">>, <<"v4">>}]},
+            %% The Server MUST send all User Properties unaltered in a
+            %% PUBLISH packet when forwarding the Application Message to
+            %% a Client [MQTT-3.3.2-17]. The Server MUST maintain the
+            %% order of User Properties when forwarding the Application
+            %% Message [MQTT-3.3.2-18].
+            #{
+                p_user_property => [
+                    {<<"k1">>, <<"v1">>},
+                    {<<"k2">>, <<"v2">>},
+                    {<<"k3">>, <<"v3">>},
+                    {<<"k2">>, <<"v4">>}
+                ]
+            },
 
-         %% A Server MUST send the Content Type unaltered to all
-         %% subscribers receiving the Application Message
-         %% [MQTT-3.3.2-20].
-         #{p_content_type => <<"content type">>}],
+            %% A Server MUST send the Content Type unaltered to all
+            %% subscribers receiving the Application Message
+            %% [MQTT-3.3.2-20].
+            #{p_content_type => <<"content type">>}
+        ],
 
     PubConnect = packetv5:gen_connect("property-passthrough-pub-test", [{keepalive, 60}]),
     PubConnack = packetv5:gen_connack(0, ?M5_CONNACK_ACCEPT, #{}),
     {ok, PubSocket} = packetv5:do_client_connect(PubConnect, PubConnack, []),
 
     lists:foreach(
-      fun(Property) ->
-              ct:pal("Testing property: ~p", [Property]),
-              Pub = packetv5:gen_publish(Topic, 0, <<"message">>,
-                                         [{properties, Property}]),
-              ok = gen_tcp:send(PubSocket, Pub),
-              ok = packetv5:expect_frame(SubSocket, Pub)
-      end, Properties),
+        fun(Property) ->
+            ct:pal("Testing property: ~p", [Property]),
+            Pub = packetv5:gen_publish(
+                Topic,
+                0,
+                <<"message">>,
+                [{properties, Property}]
+            ),
+            ok = gen_tcp:send(PubSocket, Pub),
+            ok = packetv5:expect_frame(SubSocket, Pub)
+        end,
+        Properties
+    ),
 
     disable_on_publish(),
     disable_on_subscribe().
@@ -1172,15 +1385,18 @@ max_packet_size(Config) ->
     SubClientId = vmq_cth:ustr(Config) ++ "-sub",
     PubClientId = vmq_cth:ustr(Config) ++ "-pub",
     Topic = list_to_binary(vmq_cth:utopic(Config)),
-    Pub = packetv5:gen_publish(Topic, 0, <<"publish">>, [{properties,
-                                                          #{p_user_property => [{<<"hello">>, <<"world">>}]}}]),
+    Pub = packetv5:gen_publish(Topic, 0, <<"publish">>, [
+        {properties, #{p_user_property => [{<<"hello">>, <<"world">>}]}}
+    ]),
     ReducedPub = packetv5:gen_publish(Topic, 0, <<"publish">>, []),
     TooLargePub = packetv5:gen_publish(Topic, 0, <<"large enough to be discarded publish">>, []),
-    SubConnect = packetv5:gen_connect(SubClientId,
-                                      [{keepalive, 60}, {properties, #{p_max_packet_size => iolist_size(ReducedPub)}}]),
+    SubConnect = packetv5:gen_connect(
+        SubClientId,
+        [{keepalive, 60}, {properties, #{p_max_packet_size => iolist_size(ReducedPub)}}]
+    ),
     SubConnack = packetv5:gen_connack(0, ?M5_CONNACK_ACCEPT, #{}),
     {ok, SubSocket} = packetv5:do_client_connect(SubConnect, SubConnack, []),
-    Subscribe = packetv5:gen_subscribe(77, [packetv5:gen_subtopic(Topic,0)], #{}),
+    Subscribe = packetv5:gen_subscribe(77, [packetv5:gen_subtopic(Topic, 0)], #{}),
     ok = gen_tcp:send(SubSocket, Subscribe),
     SubAck = packetv5:gen_suback(77, [0], #{}),
     ok = packetv5:expect_frame(SubSocket, SubAck),
@@ -1209,44 +1425,47 @@ max_packet_size(Config) ->
 direct_plugin_exports_test(Cfg) ->
     Topic = vmq_cth:utopic(Cfg),
     WTopic = re:split(list_to_binary(Topic), <<"/">>),
-    {RegFun0, PubFun3, {SubFun1, UnsubFun1}}
-        = vmq_reg:direct_plugin_exports(?FUNCTION_NAME),
+    {RegFun0, PubFun3, {SubFun1, UnsubFun1}} =
+        vmq_reg:direct_plugin_exports(?FUNCTION_NAME),
     ok = RegFun0(),
     {ok, [0]} = SubFun1(WTopic),
     %% this client-id generation is taken from
     %% `vmq_reg:direct_plugin_exports/1`. It would be better if that
     %% function would return the generated client-id.
     ClientId = fun(T) ->
-                       list_to_binary(
-                         base64:encode_to_string(
-                           integer_to_binary(
-                             erlang:phash2(T)
-                            )
-                          ))
-               end,
+        list_to_binary(
+            base64:encode_to_string(
+                integer_to_binary(
+                    erlang:phash2(T)
+                )
+            )
+        )
+    end,
     TestSub =
         fun(T, MustBePresent) ->
-                Subscribers = vmq_reg_trie:fold({"", ClientId(self())},
-                                                T, fun(E,_From,Acc) -> [E|Acc] end, []),
-                IsPresent = lists:member({{"", ClientId(self())}, 0}, Subscribers),
-                MustBePresent =:= IsPresent
+            Subscribers = vmq_reg_trie:fold(
+                {"", ClientId(self())},
+                T,
+                fun(E, _From, Acc) -> [E | Acc] end,
+                []
+            ),
+            IsPresent = lists:member({{"", ClientId(self())}, 0}, Subscribers),
+            MustBePresent =:= IsPresent
         end,
     vmq_cluster_test_utils:wait_until(fun() -> TestSub(WTopic, true) end, 100, 10),
     {ok, {1, 0}} = PubFun3(WTopic, <<"msg1">>, #{}),
     receive
         {deliver, WTopic, <<"msg1">>, 0, false, false} -> ok;
         Other -> throw({received_unexpected_msg, Other})
-    after
-        1000 ->
-            throw(didnt_receive_expected_msg_from_direct_plugin_exports)
+    after 1000 ->
+        throw(didnt_receive_expected_msg_from_direct_plugin_exports)
     end,
     ok = UnsubFun1(WTopic),
     vmq_cluster_test_utils:wait_until(fun() -> TestSub(WTopic, false) end, 100, 10),
     {ok, {0, 0}} = PubFun3(WTopic, <<"msg2">>, #{}),
     receive
         M -> throw({received_unexpected_msg_from_direct_plugin_exports, M})
-    after
-        100 -> ok
+    after 100 -> ok
     end.
 
 %% publish_c2b_invalid_topic_alias(Config) ->
@@ -1267,7 +1486,8 @@ hook_auth_on_publish(_, _, _, _, _, _) -> ok.
 hook_on_message_drop(_, Promise, max_packet_size_exceeded) ->
     {_QoS, _Topic, <<"large enough to be discarded publish">> = _Payload, _Props} = Promise(),
     ok;
-hook_on_message_drop({"", <<"message-expiry-sub">>}, _, expired) -> ok.
+hook_on_message_drop({"", <<"message-expiry-sub">>}, _, expired) ->
+    ok.
 
 hook_on_client_offline(SubscriberId) ->
     ?CLIENT_OFFLINE_EVENT_SRV ! {on_client_offline, SubscriberId}.
@@ -1277,40 +1497,57 @@ hook_on_client_offline(SubscriberId) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 enable_on_subscribe() ->
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
+        auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3
+    ),
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
-                     convert, 4}}]).
+        auth_on_subscribe,
+        ?MODULE,
+        hook_auth_on_subscribe,
+        3,
+        [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5, convert, 4}}]
+    ).
 enable_on_publish() ->
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
+        auth_on_publish, ?MODULE, hook_auth_on_publish, 6
+    ),
     ok = vmq_plugin_mgr:enable_module_plugin(
-           auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
-                    convert, 7}}]).
+        auth_on_publish,
+        ?MODULE,
+        hook_auth_on_publish,
+        6,
+        [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5, convert, 7}}]
+    ).
 enable_on_message_drop() ->
     ok = vmq_plugin_mgr:enable_module_plugin(
-           on_message_drop, ?MODULE, hook_on_message_drop, 3).
+        on_message_drop, ?MODULE, hook_on_message_drop, 3
+    ).
 
 disable_on_subscribe() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3),
+        auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3
+    ),
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_subscribe, ?MODULE, hook_auth_on_subscribe, 3,
-           [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5,
-                      convert, 4}}]).
+        auth_on_subscribe,
+        ?MODULE,
+        hook_auth_on_subscribe,
+        3,
+        [{compat, {auth_on_subscribe_m5, vmq_plugin_compat_m5, convert, 4}}]
+    ).
 disable_on_publish() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_publish, ?MODULE, hook_auth_on_publish, 6),
+        auth_on_publish, ?MODULE, hook_auth_on_publish, 6
+    ),
     ok = vmq_plugin_mgr:disable_module_plugin(
-           auth_on_publish, ?MODULE, hook_auth_on_publish, 6,
-           [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5,
-                      convert, 7}}]).
+        auth_on_publish,
+        ?MODULE,
+        hook_auth_on_publish,
+        6,
+        [{compat, {auth_on_publish_m5, vmq_plugin_compat_m5, convert, 7}}]
+    ).
 disable_on_message_drop() ->
     ok = vmq_plugin_mgr:disable_module_plugin(
-           on_message_drop, ?MODULE, hook_on_message_drop, 3).
-
+        on_message_drop, ?MODULE, hook_on_message_drop, 3
+    ).
 
 helper_pub_qos1(ClientId, Mid, Publish, Config) ->
     Connect = mqtt5_v4compat:gen_connect(ClientId, [{keepalive, 60}], Config),
@@ -1354,47 +1591,89 @@ wait_for_offline_event(ClientId, Timeout) ->
         case is_list(ClientId) of
             true ->
                 list_to_binary(ClientId);
-            false -> ClientId
+            false ->
+                ClientId
         end,
     receive
         {on_client_offline, {"", ClientIdBin}} ->
             ok
-    after
-        Timeout ->
-            throw(client_not_offline)
+    after Timeout ->
+        throw(client_not_offline)
     end.
 
 start_client_offline_events(Cfg) ->
     ok = vmq_plugin_mgr:enable_module_plugin(
-           on_client_offline, ?MODULE, hook_on_client_offline, 1),
+        on_client_offline, ?MODULE, hook_on_client_offline, 1
+    ),
     TestPid = self(),
     F = fun(Fun) ->
-                receive
-                    {on_client_offline, _} = E ->
-                        TestPid ! E,
-                        Fun(Fun);
-                    {stop, Ref} ->
-                        TestPid ! {ok, Ref},
-                        ok
-                end
-        end,
+        receive
+            {on_client_offline, _} = E ->
+                TestPid ! E,
+                Fun(Fun);
+            {stop, Ref} ->
+                TestPid ! {ok, Ref},
+                ok
+        end
+    end,
     EventProc = spawn_link(fun() -> F(F) end),
     true = register(?CLIENT_OFFLINE_EVENT_SRV, EventProc),
-    [{?CLIENT_OFFLINE_EVENT_SRV, EventProc}|Cfg].
-
+    [{?CLIENT_OFFLINE_EVENT_SRV, EventProc} | Cfg].
 
 stop_client_offline_events(Cfg) ->
     ok = vmq_plugin_mgr:disable_module_plugin(
-           on_client_offline, ?MODULE, hook_on_client_offline, 1),
+        on_client_offline, ?MODULE, hook_on_client_offline, 1
+    ),
     Pid = proplists:get_value(?CLIENT_OFFLINE_EVENT_SRV, Cfg),
     Ref = make_ref(),
     Pid ! {stop, Ref},
     receive
         {ok, Ref} ->
             ok
-    after
-        1000 ->
-            throw({could_not_stop, ?CLIENT_OFFLINE_EVENT_SRV})
+    after 1000 ->
+        throw({could_not_stop, ?CLIENT_OFFLINE_EVENT_SRV})
     end.
 
-receive_at_most_n_frames(Pid, Socket, N, QoS, Cfg) -> Pid ! {self(), mqtt5_v4compat:receive_at_most_n_frames(Socket, N, QoS, Cfg)}.
+receive_at_most_n_frames(Pid, Socket, N, QoS, Cfg) ->
+    Pid ! {self(), mqtt5_v4compat:receive_at_most_n_frames(Socket, N, QoS, Cfg)}.
+
+compare_published_packets_payload(PublishedPackets, ReceivedF1, ReceivedF2) ->
+    PublishedPayloads = lists:map(
+        fun(P) ->
+            {#mqtt_publish{payload = Payload}, _} = vmq_parser:parse(P),
+            Payload
+        end,
+        PublishedPackets
+    ),
+
+    ReceivedPayloads1 = lists:map(
+        fun(#mqtt_publish{payload = Payload}) ->
+            Payload
+        end,
+        ReceivedF1
+    ),
+    ReceivedPayloads2 = lists:map(
+        fun(#mqtt_publish{payload = Payload}) ->
+            Payload
+        end,
+        ReceivedF2
+    ),
+
+    check_order_(PublishedPayloads, ReceivedPayloads1, ReceivedPayloads2).
+
+check_order_([], _, _) ->
+    ok;
+check_order_(ExpectedPayload = [NextPayload | Rest], Received1, Received2) ->
+    {Result1, UpdatedReceived1} = remove_first_(NextPayload, Received1),
+    {Result2, UpdatedReceived2} = remove_first_(NextPayload, Received2),
+    case {Result1, Result2} of
+        {none, none} ->
+            erlang:error({assertion_failed, {incorrect_order, ExpectedPayload}});
+        {_, _} ->
+            check_order_(Rest, UpdatedReceived1, UpdatedReceived2)
+    end.
+
+remove_first_(Payload, [Payload | Rest]) ->
+    {Payload, Rest};
+remove_first_(_, List) ->
+    {none, List}.

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -1086,8 +1086,8 @@ shared_subscription_does_not_honor_grouping(Cfg) ->
             Publish
         end,
     PublishedPackets = [PubFun(PubSocket, Mid) || Mid <- lists:seq(1, 10)],
-    Pid1 = spawn(?MODULE, receive_at_most_n_frames, [self(), SubSocket1, 10, 1, Cfg]),
-    Pid2 = spawn(?MODULE, receive_at_most_n_frames, [self(), SubSocket2, 10, 1, Cfg]),
+    Pid1 = spawn(?MODULE, receive_at_most_n_publish_frames, [self(), SubSocket1, 10, 1, Cfg]),
+    Pid2 = spawn(?MODULE, receive_at_most_n_publish_frames, [self(), SubSocket2, 10, 1, Cfg]),
     ReceivedF1 =
         receive
             {Pid1, Res1} -> Res1
@@ -1634,8 +1634,8 @@ stop_client_offline_events(Cfg) ->
         throw({could_not_stop, ?CLIENT_OFFLINE_EVENT_SRV})
     end.
 
-receive_at_most_n_frames(Pid, Socket, N, QoS, Cfg) ->
-    Pid ! {self(), mqtt5_v4compat:receive_at_most_n_frames(Socket, N, QoS, Cfg)}.
+receive_at_most_n_publish_frames(Pid, Socket, N, QoS, Cfg) ->
+    Pid ! {self(), mqtt5_v4compat:receive_at_most_n_publish_frames(Socket, N, QoS, Cfg)}.
 
 compare_published_packets_payload(PublishedPackets, ReceivedF1, ReceivedF2) ->
     PublishedPayloads = lists:map(


### PR DESCRIPTION
## Proposed Changes

Cache the message routing of shared subscribers in-memory.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

**Local shared subscriptions currently do not honor shared subscription groups properly.**
**It is recommended to use shared subscription topics only for shared subscription use-cases. Do not expect broker to route msgs for same topic to both shared subscribers and normal subscribers. It will only route to shared subscribers irrespective of shared subscription groups.**
