### PR TITLE
Fix swapped position of retry and persistence label flag in metric definition.

### DIFF
--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -1485,7 +1485,7 @@ counter_entries_def() ->
                 {non_persistence, rcn_to_str(?NON_PERSISTENCE)},
                 {non_retry, rcn_to_str(?NON_RETRY)}
             ],
-            {?QOS1_SUBSCRIPTION_OPTS, ?NON_PERSISTENCE, ?NON_RETRY},
+            {?QOS1_SUBSCRIPTION_OPTS, ?NON_RETRY, ?NON_PERSISTENCE},
             qos1_subscription_opts,
             <<"QoS 1 opts in subscription.">>
         ),
@@ -1496,7 +1496,7 @@ counter_entries_def() ->
                 {non_persistence, rcn_to_str(?NON_PERSISTENCE)},
                 {non_retry, rcn_to_str(?RETRY)}
             ],
-            {?QOS1_SUBSCRIPTION_OPTS, ?NON_PERSISTENCE, ?RETRY},
+            {?QOS1_SUBSCRIPTION_OPTS, ?RETRY, ?NON_PERSISTENCE},
             qos1_subscription_opts,
             <<"QoS 1 opts in subscription.">>
         ),
@@ -1507,7 +1507,7 @@ counter_entries_def() ->
                 {non_persistence, rcn_to_str(?PERSISTENCE)},
                 {non_retry, rcn_to_str(?NON_RETRY)}
             ],
-            {?QOS1_SUBSCRIPTION_OPTS, ?PERSISTENCE, ?NON_RETRY},
+            {?QOS1_SUBSCRIPTION_OPTS, ?NON_RETRY, ?PERSISTENCE},
             qos1_subscription_opts,
             <<"QoS 1 opts in subscription.">>
         ),
@@ -1518,7 +1518,7 @@ counter_entries_def() ->
                 {non_persistence, rcn_to_str(?PERSISTENCE)},
                 {non_retry, rcn_to_str(?RETRY)}
             ],
-            {?QOS1_SUBSCRIPTION_OPTS, ?PERSISTENCE, ?RETRY},
+            {?QOS1_SUBSCRIPTION_OPTS, ?RETRY, ?PERSISTENCE},
             qos1_subscription_opts,
             <<"QoS 1 opts in subscription.">>
         ),


### PR DESCRIPTION
## Proposed Changes

Fixes the wrong position of retry and persistence flag in metric definition.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
