### PR TITLE
Fix offline store process crash

### DIFF
--- a/apps/vmq_generic_offline_msg_store/src/engines/vmq_offline_storage_engine_redis.erl
+++ b/apps/vmq_generic_offline_msg_store/src/engines/vmq_offline_storage_engine_redis.erl
@@ -26,15 +26,7 @@ open(Opts) ->
                                {timeout, proplists:get_value(connect_timeout, Opts, 5000)}]
                     },
                    {database, Database}],
-    open_(ConnectOpts).
-open_(Opts) ->
-    case eredis:start_link(Opts) of
-        {ok, _} = OkResponse -> OkResponse;
-        {error, Reason} ->
-            lager:error("Error connecting db: ~p", [Reason]),
-            timer:sleep(2000),
-            open_(Opts)
-    end.
+    eredis:start_link(ConnectOpts).
 
 write(Client, SIdB, _MsgRef, MsgB, Timeout) ->
     vmq_redis:query(Client, ["RPUSH", SIdB, MsgB], ?RPUSH, ?MSG_STORE_WRITE, Timeout).


### PR DESCRIPTION
## Proposed Changes

The process state got overridden while updating one of its field on reconnect. This caused the contents of the state to set as undefined resulting in crash when in use.

Fixes the auto recovery in case of vmq_offline_msg_store process crash. Sets the good state on redis reconnect.
## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging