### PR TITLE
fix: routing messages on not_allowed shared sub topics which are locally cached

### DIFF
--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -152,7 +152,9 @@ subscribe_op({MP, ClientId} = SubscriberId, Topics) ->
                                 Value = {ClientId, QoS},
                                 ets:insert(?SHARED_SUBS_ETS_TABLE, {{Key, Value}}),
                                 vmq_metrics:incr_cache_insert(?LOCAL_SHARED_SUBS);
-                            ({[<<"$share">>, _Group | Topic], {QoS, _Opts} = QoSWithOpts}) when is_integer(QoS) ->
+                            ({[<<"$share">>, _Group | Topic], {QoS, _Opts} = QoSWithOpts}) when
+                                is_integer(QoS)
+                            ->
                                 Key = {MP, Topic},
                                 Value = {ClientId, QoSWithOpts},
                                 ets:insert(?SHARED_SUBS_ETS_TABLE, {{Key, Value}}),

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -147,9 +147,14 @@ subscribe_op({MP, ClientId} = SubscriberId, Topics) ->
                 CacheLocally ->
                     lists:foreach(
                         fun
-                            ({[<<"$share">>, _Group | Topic], QoS}) ->
+                            ({[<<"$share">>, _Group | Topic], QoS}) when is_integer(QoS) ->
                                 Key = {MP, Topic},
                                 Value = {ClientId, QoS},
+                                ets:insert(?SHARED_SUBS_ETS_TABLE, {{Key, Value}}),
+                                vmq_metrics:incr_cache_insert(?LOCAL_SHARED_SUBS);
+                            ({[<<"$share">>, _Group | Topic], {QoS, _Opts} = QoSWithOpts}) when is_integer(QoS) ->
+                                Key = {MP, Topic},
+                                Value = {ClientId, QoSWithOpts},
                                 ets:insert(?SHARED_SUBS_ETS_TABLE, {{Key, Value}}),
                                 vmq_metrics:incr_cache_insert(?LOCAL_SHARED_SUBS);
                             (_) ->


### PR DESCRIPTION
## Proposed Changes
Shared subscription topics which were not_allowed were getting cached. The client which received 128 for that topic still received the messages on the topic.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

