### PR TITLE
feat: add vscode devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM erlang:23.0.3-alpine
+RUN apk add --no-cache snappy-dev openssl-dev alpine-sdk bsd-compat-headers bash git make
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1001
+ARG GRPNAME=vscodegrp
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN addgroup -g $USER_GID $GRPNAME \
+    && adduser -u $USER_UID -g $GRPNAME -D $USERNAME
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.159.0/containers/javascript-node
+{
+	"name": "Erlang",
+
+	"service": "vernemq",
+	"shutdownAction": "none",
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+	"workspaceFolder": "/workspace/vernemq",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"pgourlain.erlang"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [1883, 8888],
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - 6379:6379
+  redis-sentinel:
+    image: bitnami/redis-sentinel
+    container_name: redis-sentinel
+    ports:
+      - 26379:26379
+  vernemq:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    container_name: vernemq
+    volumes:
+      - .:/workspace/vernemq:cached
+    command: /bin/bash -c "while sleep 100; do :; done"
+    depends_on:
+      - redis
+      - redis-sentinel


### PR DESCRIPTION
## Proposed Changes

Add vscode devcontainer support allowing devs easily setup and run the application locally. At present, the application is giving errors on apple silicon arm64 arch while compilation.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [x] DevOps (Build scripts, pipelines...)
