### PR TITLE
fix: shared sub routing on node down

### DIFF
--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -97,7 +97,8 @@
     incr_cache_miss/1,
 
     incr_msg_enqueue_subscriber_not_found/0,
-    incr_topic_counter/1
+    incr_topic_counter/1,
+    incr_shared_subscription_group_publish_attempt_failed/0
 ]).
 
 -export([
@@ -328,6 +329,9 @@ incr_cache_miss(NAME) ->
 
 incr_msg_enqueue_subscriber_not_found() ->
     incr_item(msg_enqueue_subscriber_not_found, 1).
+
+incr_shared_subscription_group_publish_attempt_failed() ->
+    incr_item(shared_subscription_group_publish_attempt_failed, 1).
 
 incr(Entry) ->
     incr_item(Entry, 1).
@@ -1842,6 +1846,13 @@ counter_entries_def() ->
             msg_enqueue_subscriber_not_found,
             msg_enqueue_subscriber_not_found,
             <<"The number of times subscriber was not found when message had to be enqueued.">>
+        ),
+        m(
+            counter,
+            [],
+            shared_subscription_group_publish_attempt_failed,
+            shared_subscription_group_publish_attempt_failed,
+            <<"The number of times publish attempt failed for a shared subscription group.">>
         )
     ].
 
@@ -2900,7 +2911,8 @@ met2idx({?MQTT_DISONNECT, ?REASON_INVALID_PUBCOMP_ERROR}) -> 356;
 met2idx({?MQTT_DISONNECT, ?REASON_UNEXPECTED_FRAME_TYPE}) -> 357;
 met2idx({?MQTT_DISONNECT, ?REASON_EXIT_SIGNAL_RECEIVED}) -> 358;
 met2idx({?MQTT_DISONNECT, ?REASON_TCP_CLOSED}) -> 359;
-met2idx({?MQTT_DISONNECT, ?REASON_UNSPECIFIED}) -> 360.
+met2idx({?MQTT_DISONNECT, ?REASON_UNSPECIFIED}) -> 360;
+met2idx(shared_subscription_group_publish_attempt_failed) -> 361.
 
 -ifdef(TEST).
 clear_stored_rates() ->

--- a/apps/vmq_server/src/vmq_shared_subscriptions.erl
+++ b/apps/vmq_server/src/vmq_shared_subscriptions.erl
@@ -42,6 +42,7 @@ publish(Msg, Policy, [{Group, SubscriberGroup} | Rest], Acc0) ->
                 "can't publish to shared subscription ~p due to '~p', msg: ~p",
                 [Group, Reason, Msg]
             ),
+            vmq_metrics:incr_shared_subscription_group_publish_attempt_failed(),
             publish(Msg, Policy, Rest, Acc0)
     end.
 
@@ -52,11 +53,16 @@ publish_to_group(
 ) ->
     case publish_online(Msg, Subscriber, Acc0) of
         {error, different_node} ->
-            case vmq_redis_queue:enqueue(Node, term_to_binary(RandSubs), term_to_binary(Msg)) of
-                ok ->
-                    {ok, {Local, Remote + 1}};
-                E ->
-                    E
+            case vmq_cluster_mon:is_node_alive(Node) of
+                true ->
+                    case vmq_redis_queue:enqueue(Node, term_to_binary(RandSubs), term_to_binary(Msg)) of
+                        ok ->
+                            {ok, {Local, Remote + 1}};
+                        E ->
+                            E
+                    end;
+                _ ->
+                    publish_to_group(Msg, Rest, Acc0)
             end;
         {ok, Acc1} ->
             {ok, Acc1};

--- a/apps/vmq_server/src/vmq_shared_subscriptions.erl
+++ b/apps/vmq_server/src/vmq_shared_subscriptions.erl
@@ -55,7 +55,9 @@ publish_to_group(
         {error, different_node} ->
             case vmq_cluster_mon:is_node_alive(Node) of
                 true ->
-                    case vmq_redis_queue:enqueue(Node, term_to_binary(RandSubs), term_to_binary(Msg)) of
+                    case
+                        vmq_redis_queue:enqueue(Node, term_to_binary(RandSubs), term_to_binary(Msg))
+                    of
                         ok ->
                             {ok, {Local, Remote + 1}};
                         E ->


### PR DESCRIPTION
## Proposed Changes

Fixes the shared subscription routing when node goes down. At present, the remote node enqueues the messages in the main queue of the dead node without checking if the main queue of the node is dead or not. It continues to enqueue until the subscription state returns the dead node containing the subscriber. 

The fix checks the status of node before enqueue and if the node is dead, then it moves to the next subscriber in the shared subscription group.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

