### PR TITLE
fix: complex topic removal flow

### DIFF
--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -607,7 +607,15 @@ acl_test_() ->
         {"Simple ACL Test - vmq_reg_trie", ?setup(fun simple_acl/1)},
         {"Simple ACL Test - Delete aged acl test", ?setup(fun delete_aged_acl_test/1)},
         {"Simple ACL Test - vmq_reg_redis_trie",
-            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun simple_acl/1}}
+            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun simple_acl/1}},
+        {"Complex ACL Test - Add complex topic",
+            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun add_complex_acl_test/1}},
+        {"Complex ACL Test - Delete complex topic",
+            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun delete_complex_acl_test/1}},
+        {"Complex ACL Test - Sub-topic whitelisting",
+            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun subtopic_subscribe_test/1}},
+        {"Complex ACL Test - Get individual complex topics",
+            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun get_complex_topics_test/1}}
     ].
 
 setup() ->
@@ -621,20 +629,16 @@ setup_vmq_reg_redis_trie() ->
     init(),
     ets:new(?TOPIC_LABEL_TABLE, [named_table, public, {write_concurrency, true}]),
     ets:new(vmq_redis_trie_node, [{keypos, 2} | ?TABLE_OPTS]),
-    ets:insert(
-        vmq_redis_trie_node, #trie_node{
-            node_id = {"", [<<"x">>, <<"y">>, <<"z">>, <<"#">>]},
-            traversal_count = 1,
-            topic = [
-                <<"x">>, <<"y">>, <<"z">>, <<"#">>
-            ]
-        }
-    ),
+    ets:new(vmq_redis_trie, [{keypos, 2} | ?TABLE_OPTS]),
+    vmq_reg_redis_trie:add_complex_topic("", [<<"x">>, <<"y">>, <<"z">>, <<"#">>]),
     vmq_reg_redis_trie.
 teardown(RegView) ->
     case RegView of
-        vmq_reg_redis_trie -> ets:delete(vmq_redis_trie_node);
-        _ -> ok
+        vmq_reg_redis_trie ->
+            ets:delete(vmq_redis_trie),
+            ets:delete(vmq_redis_trie_node);
+        _ ->
+            ok
     end,
     ets:delete(vmq_enhanced_auth_acl_read_all),
     ets:delete(vmq_enhanced_auth_acl_write_all),
@@ -1000,6 +1004,141 @@ delete_aged_acl_test(_) ->
         ?_assertEqual(
             [],
             ets:match(vmq_enhanced_auth_acl_write_token, {'_', 2, '$1'})
+        )
+    ].
+add_complex_acl_test(_) ->
+    ACL = [<<"topic abc/xyz/#\n">>],
+    load_from_list(ACL),
+    Topic1 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>],
+    Topic2 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"2">>],
+    vmq_reg_redis_trie:add_complex_topic("", Topic1),
+    vmq_reg_redis_trie:add_complex_topic("", Topic2),
+    [
+        ?_assertEqual(
+            {ok, [
+                {Topic1, 0}
+            ]},
+            auth_on_subscribe(
+                <<"test">>,
+                {"", <<"my-client-id">>},
+                [
+                    {Topic1, 0}
+                ]
+            )
+        ),
+        ?_assertEqual(
+            {ok, [
+                {Topic2, 0}
+            ]},
+            auth_on_subscribe(
+                <<"test">>,
+                {"", <<"my-client-id">>},
+                [
+                    {Topic2, 0}
+                ]
+            )
+        )
+    ].
+delete_complex_acl_test(_) ->
+    ACL = [<<"topic abc/xyz/#\n">>],
+    load_from_list(ACL),
+    Topic1 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>],
+    Topic2 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"2">>],
+    SubTopic = [<<"abc">>, <<"xyz">>, <<"+">>],
+    vmq_reg_redis_trie:add_complex_topic("", Topic1),
+    vmq_reg_redis_trie:add_complex_topic("", Topic2),
+    vmq_reg_redis_trie:delete_complex_topic("", Topic1),
+    vmq_reg_redis_trie:delete_complex_topic("", SubTopic),
+    [
+        ?_assertEqual(
+            next,
+            auth_on_subscribe(
+                <<"test">>,
+                {"", <<"my-client-id">>},
+                [
+                    {Topic1, 0}
+                ]
+            )
+        ),
+        ?_assertEqual(
+            {ok, [
+                {Topic2, 0}
+            ]},
+            auth_on_subscribe(
+                <<"test">>,
+                {"", <<"my-client-id">>},
+                [
+                    {Topic2, 0}
+                ]
+            )
+        )
+    ].
+subtopic_subscribe_test(_) ->
+    ACL = [<<"topic abc/xyz/#\n">>],
+    load_from_list(ACL),
+    Topic = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>, <<"+">>],
+    SubTopic1 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>],
+    SubTopic2 = [<<"abc">>, <<"xyz">>, <<"+">>],
+    vmq_reg_redis_trie:add_complex_topic("", Topic),
+    vmq_reg_redis_trie:add_complex_topic("", SubTopic1),
+    [
+        ?_assertEqual(
+            {ok, [
+                {Topic, 0}
+            ]},
+            auth_on_subscribe(
+                <<"test">>,
+                {"", <<"my-client-id">>},
+                [
+                    {Topic, 0}
+                ]
+            )
+        ),
+        ?_assertEqual(
+            {ok, [
+                {SubTopic1, 0}
+            ]},
+            auth_on_subscribe(
+                <<"test">>,
+                {"", <<"my-client-id">>},
+                [
+                    {SubTopic1, 0}
+                ]
+            )
+        ),
+        ?_assertEqual(
+            next,
+            auth_on_subscribe(
+                <<"test">>,
+                {"", <<"my-client-id">>},
+                [
+                    {SubTopic2, 0}
+                ]
+            )
+        )
+    ].
+get_complex_topics_test(_) ->
+    ACL = [<<"topic abc/xyz/#\n">>],
+    load_from_list(ACL),
+    Topic1 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>, <<"+">>],
+    Topic2 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"2">>],
+    Topic3 = [<<"x">>, <<"y">>, <<"z">>, <<"#">>],
+    SubTopic1 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>],
+    vmq_reg_redis_trie:add_complex_topic("", Topic1),
+    vmq_reg_redis_trie:add_complex_topic("", Topic2),
+    vmq_reg_redis_trie:add_complex_topic("", SubTopic1),
+    vmq_reg_redis_trie:delete_complex_topic("", Topic3),
+    [
+        ?_assertEqual(
+            [
+                [<<"abc/xyz/+/1/+">>],
+                [<<"abc/xyz/+/1">>],
+                [<<"abc/xyz/+/2">>]
+            ],
+            [
+                [iolist_to_binary((Topic))]
+             || Topic <- vmq_reg_redis_trie:get_complex_topics()
+            ]
         )
     ].
 -endif.

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -622,10 +622,13 @@ setup_vmq_reg_redis_trie() ->
     ets:new(?TOPIC_LABEL_TABLE, [named_table, public, {write_concurrency, true}]),
     ets:new(vmq_redis_trie_node, [{keypos, 2} | ?TABLE_OPTS]),
     ets:insert(
-        vmq_redis_trie_node,
-        {trie_node, {"", [<<"x">>, <<"y">>, <<"z">>, <<"#">>]}, [
-            <<"x">>, <<"y">>, <<"z">>, <<"#">>
-        ]}
+        vmq_redis_trie_node, #trie_node{
+            node_id = {"", [<<"x">>, <<"y">>, <<"z">>, <<"#">>]},
+            traversal_count = 1,
+            topic = [
+                <<"x">>, <<"y">>, <<"z">>, <<"#">>
+            ]
+        }
     ),
     vmq_reg_redis_trie.
 teardown(RegView) ->

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -1016,7 +1016,7 @@ add_complex_acl_test(_) ->
     [
         ?_assertEqual(
             {ok, [
-                {Topic1, 0}
+                {Topic1, 0, {matched_acl, undefined, <<"abc/xyz/#">>}}
             ]},
             auth_on_subscribe(
                 <<"test">>,
@@ -1028,7 +1028,7 @@ add_complex_acl_test(_) ->
         ),
         ?_assertEqual(
             {ok, [
-                {Topic2, 0}
+                {Topic2, 0, {matched_acl, undefined, <<"abc/xyz/#">>}}
             ]},
             auth_on_subscribe(
                 <<"test">>,
@@ -1062,7 +1062,7 @@ delete_complex_acl_test(_) ->
         ),
         ?_assertEqual(
             {ok, [
-                {Topic2, 0}
+                {Topic2, 0, {matched_acl, undefined, <<"abc/xyz/#">>}}
             ]},
             auth_on_subscribe(
                 <<"test">>,
@@ -1084,7 +1084,7 @@ subtopic_subscribe_test(_) ->
     [
         ?_assertEqual(
             {ok, [
-                {Topic, 0}
+                {Topic, 0, {matched_acl, undefined, <<"abc/xyz/#">>}}
             ]},
             auth_on_subscribe(
                 <<"test">>,
@@ -1096,7 +1096,7 @@ subtopic_subscribe_test(_) ->
         ),
         ?_assertEqual(
             {ok, [
-                {SubTopic1, 0}
+                {SubTopic1, 0, {matched_acl, undefined, <<"abc/xyz/#">>}}
             ]},
             auth_on_subscribe(
                 <<"test">>,

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -40,6 +40,8 @@
 
 -import(vmq_topic, [words/1, match/2]).
 
+-include("apps/vmq_server/src/vmq_server.hrl").
+
 -define(INIT_ACL, {[], [], [], [], [], []}).
 -define(TABLES, [
     vmq_enhanced_auth_acl_read_pattern,
@@ -554,8 +556,11 @@ is_complex_topic_whitelisted([<<"$share">> | _] = _Topic) ->
 is_complex_topic_whitelisted(Topic) ->
     MPTopic = {"", Topic},
     case ets:lookup(vmq_redis_trie_node, MPTopic) of
-        [_] ->
-            true;
+        [#trie_node{topic = NodeTopic} = _TrieNode] ->
+            case NodeTopic of
+                undefined -> false;
+                _ -> true
+            end;
         _ ->
             false
     end.

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -607,15 +607,7 @@ acl_test_() ->
         {"Simple ACL Test - vmq_reg_trie", ?setup(fun simple_acl/1)},
         {"Simple ACL Test - Delete aged acl test", ?setup(fun delete_aged_acl_test/1)},
         {"Simple ACL Test - vmq_reg_redis_trie",
-            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun simple_acl/1}},
-        {"Complex ACL Test - Add complex topic",
-            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun add_complex_acl_test/1}},
-        {"Complex ACL Test - Delete complex topic",
-            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun delete_complex_acl_test/1}},
-        {"Complex ACL Test - Sub-topic whitelisting",
-            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun subtopic_subscribe_test/1}},
-        {"Complex ACL Test - Get individual complex topics",
-            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun get_complex_topics_test/1}}
+            {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun simple_acl/1}}
     ].
 
 setup() ->

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -1078,21 +1078,22 @@ delete_complex_acl_test(_) ->
 subtopic_subscribe_test(_) ->
     ACL = [<<"topic abc/xyz/#\n">>],
     load_from_list(ACL),
-    Topic = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>, <<"+">>],
+    Topic1 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>, <<"+">>],
+    Topic2 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"2">>],
     SubTopic1 = [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>],
     SubTopic2 = [<<"abc">>, <<"xyz">>, <<"+">>],
-    vmq_reg_redis_trie:add_complex_topic("", Topic),
+    vmq_reg_redis_trie:add_complex_topic("", Topic1),
     vmq_reg_redis_trie:add_complex_topic("", SubTopic1),
     [
         ?_assertEqual(
             {ok, [
-                {Topic, 0, {matched_acl, undefined, <<"abc/xyz/#">>}}
+                {Topic1, 0, {matched_acl, undefined, <<"abc/xyz/#">>}}
             ]},
             auth_on_subscribe(
                 <<"test">>,
                 {"", <<"my-client-id">>},
                 [
-                    {Topic, 0}
+                    {Topic1, 0}
                 ]
             )
         ),
@@ -1117,6 +1118,22 @@ subtopic_subscribe_test(_) ->
                     {SubTopic2, 0}
                 ]
             )
+        ),
+        ?_assertEqual(
+            true,
+            is_complex_topic_whitelisted(Topic1)
+        ),
+        ?_assertEqual(
+            false,
+            is_complex_topic_whitelisted(Topic2)
+        ),
+        ?_assertEqual(
+            true,
+            is_complex_topic_whitelisted(SubTopic1)
+        ),
+        ?_assertEqual(
+            false,
+            is_complex_topic_whitelisted(SubTopic2)
         )
     ].
 -endif.

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -475,48 +475,48 @@ add_complex_topic_test(_) ->
     [
         ?_assertEqual(
             [
-                {trie_node, {[], [<<"pqr">>]}, 1, undefined},
-                {trie_node, {[], [<<"pqr">>, <<"+">>]}, 1, undefined},
-                {trie_node, {[], [<<"abc">>, <<"+">>, <<"+">>]}, 0, [<<"abc">>, <<"+">>, <<"+">>]},
-                {trie_node, {[], [<<"pqr">>, <<"+">>, <<"1">>]}, 0, [<<"pqr">>, <<"+">>, <<"1">>]},
-                {trie_node, {[], [<<"abc">>, <<"+">>]}, 1, undefined},
+                {trie_node, {[], root}, 2, undefined},
                 {trie_node, {[], [<<"abc">>]}, 2, undefined},
+                {trie_node, {[], [<<"abc">>, <<"+">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"+">>, <<"+">>]}, 0, [<<"abc">>, <<"+">>, <<"+">>]},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 2, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 0, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
                 ]},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"2">>]}, 0, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"2">>
                 ]},
-                {trie_node, {[], root}, 2, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 2, undefined}
+                {trie_node, {[], [<<"pqr">>]}, 1, undefined},
+                {trie_node, {[], [<<"pqr">>, <<"+">>]}, 1, undefined},
+                {trie_node, {[], [<<"pqr">>, <<"+">>, <<"1">>]}, 0, [<<"pqr">>, <<"+">>, <<"1">>]}
             ],
-            ets:tab2list(vmq_redis_trie_node)
+            lists:usort(ets:tab2list(vmq_redis_trie_node))
         ),
         ?_assertEqual(
             [
+                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
+                {trie, {trie_edge, {[], root}, <<"pqr">>}, [<<"pqr">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"+">>}, [<<"abc">>, <<"+">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]},
+                {trie, {trie_edge, {[], [<<"abc">>, <<"+">>]}, <<"+">>}, [
+                    <<"abc">>, <<"+">>, <<"+">>
+                ]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>
                 ]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, <<"1">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
                 ]},
-                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
-                {trie, {trie_edge, {[], [<<"pqr">>]}, <<"+">>}, [<<"pqr">>, <<"+">>]},
-                {trie, {trie_edge, {[], [<<"abc">>, <<"+">>]}, <<"+">>}, [
-                    <<"abc">>, <<"+">>, <<"+">>
-                ]},
-                {trie, {trie_edge, {[], [<<"pqr">>, <<"+">>]}, <<"1">>}, [
-                    <<"pqr">>, <<"+">>, <<"1">>
-                ]},
-                {trie, {trie_edge, {[], root}, <<"pqr">>}, [<<"pqr">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, <<"2">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"2">>
                 ]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"+">>}, [<<"abc">>, <<"+">>]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]}
+                {trie, {trie_edge, {[], [<<"pqr">>]}, <<"+">>}, [<<"pqr">>, <<"+">>]},
+                {trie, {trie_edge, {[], [<<"pqr">>, <<"+">>]}, <<"1">>}, [
+                    <<"pqr">>, <<"+">>, <<"1">>
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie)
+            lists:usort(ets:tab2list(vmq_redis_trie))
         )
     ].
 add_existing_topic_test(_) ->
@@ -526,28 +526,28 @@ add_existing_topic_test(_) ->
     [
         ?_assertEqual(
             [
+                {trie_node, {[], root}, 1, undefined},
                 {trie_node, {[], [<<"abc">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 0, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
-                {trie_node, {[], root}, 1, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie_node)
+            lists:usort(ets:tab2list(vmq_redis_trie_node))
         ),
         ?_assertEqual(
             [
+                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>
                 ]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, <<"1">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie)
+            lists:usort(ets:tab2list(vmq_redis_trie))
         )
     ].
 add_sub_topic_test(_) ->
@@ -558,30 +558,30 @@ add_sub_topic_test(_) ->
     [
         ?_assertEqual(
             [
-                {trie_node, {[], [<<"abc">>]}, 1, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 0, [
-                    <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
                 {trie_node, {[], root}, 1, undefined},
+                {trie_node, {[], [<<"abc">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, [
                     <<"abc">>, <<"xyz">>, <<"+">>
+                ]},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 0, [
+                    <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
                 ]}
             ],
-            ets:tab2list(vmq_redis_trie_node)
+            lists:usort(ets:tab2list(vmq_redis_trie_node))
         ),
         ?_assertEqual(
             [
+                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>
                 ]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, <<"1">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie)
+            lists:usort(ets:tab2list(vmq_redis_trie))
         )
     ].
 delete_complex_topic_test(_) ->
@@ -596,28 +596,28 @@ delete_complex_topic_test(_) ->
     [
         ?_assertEqual(
             [
+                {trie_node, {[], root}, 1, undefined},
                 {trie_node, {[], [<<"abc">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 0, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
-                {trie_node, {[], root}, 1, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie_node)
+            lists:usort(ets:tab2list(vmq_redis_trie_node))
         ),
         ?_assertEqual(
             [
+                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>
                 ]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, <<"1">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie)
+            lists:usort(ets:tab2list(vmq_redis_trie))
         )
     ].
 delete_all_complex_topic_test(_) ->
@@ -654,34 +654,34 @@ delete_whitelisted_subtopic_test(_) ->
     [
         ?_assertEqual(
             [
+                {trie_node, {[], root}, 1, undefined},
+                {trie_node, {[], [<<"abc">>]}, 2, undefined},
+                {trie_node, {[], [<<"abc">>, <<"+">>]}, 0, [<<"abc">>, <<"+">>]},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>, <<"+">>]}, 0, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>, <<"+">>
-                ]},
-                {trie_node, {[], [<<"abc">>, <<"+">>]}, 0, [<<"abc">>, <<"+">>]},
-                {trie_node, {[], [<<"abc">>]}, 2, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 1, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
-                {trie_node, {[], root}, 1, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie_node)
+            lists:usort(ets:tab2list(vmq_redis_trie_node))
         ),
         ?_assertEqual(
             [
+                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"+">>}, [<<"abc">>, <<"+">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>
                 ]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, <<"1">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
                 ]},
-                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>, <<"+">>
-                ]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"+">>}, [<<"abc">>, <<"+">>]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie)
+            lists:usort(ets:tab2list(vmq_redis_trie))
         )
     ].
 delete_whitelisted_parent_topic_test(_) ->
@@ -693,24 +693,24 @@ delete_whitelisted_parent_topic_test(_) ->
     [
         ?_assertEqual(
             [
+                {trie_node, {[], root}, 1, undefined},
                 {trie_node, {[], [<<"abc">>]}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
-                {trie_node, {[], root}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 0, [
                     <<"abc">>, <<"xyz">>, <<"+">>
                 ]}
             ],
-            ets:tab2list(vmq_redis_trie_node)
+            lists:usort(ets:tab2list(vmq_redis_trie_node))
         ),
         ?_assertEqual(
             [
+                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>
-                ]},
-                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie)
+            lists:usort(ets:tab2list(vmq_redis_trie))
         )
     ].
 delete_non_whitelisted_subtopic_test(_) ->
@@ -723,28 +723,28 @@ delete_non_whitelisted_subtopic_test(_) ->
     [
         ?_assertEqual(
             [
+                {trie_node, {[], root}, 1, undefined},
                 {trie_node, {[], [<<"abc">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 0, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
-                {trie_node, {[], root}, 1, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie_node)
+            lists:usort(ets:tab2list(vmq_redis_trie_node))
         ),
         ?_assertEqual(
             [
+                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>
                 ]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, <<"1">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie)
+            lists:usort(ets:tab2list(vmq_redis_trie))
         )
     ].
 delete_non_existing_topic_test(_) ->
@@ -757,28 +757,28 @@ delete_non_existing_topic_test(_) ->
     [
         ?_assertEqual(
             [
+                {trie_node, {[], root}, 1, undefined},
                 {trie_node, {[], [<<"abc">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
+                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined},
                 {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>, <<"1">>]}, 0, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>]}, 1, undefined},
-                {trie_node, {[], root}, 1, undefined},
-                {trie_node, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, 1, undefined}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie_node)
+            lists:usort(ets:tab2list(vmq_redis_trie_node))
         ),
         ?_assertEqual(
             [
+                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
+                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>]}, <<"+">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>
                 ]},
                 {trie, {trie_edge, {[], [<<"abc">>, <<"xyz">>, <<"+">>]}, <<"1">>}, [
                     <<"abc">>, <<"xyz">>, <<"+">>, <<"1">>
-                ]},
-                {trie, {trie_edge, {[], root}, <<"abc">>}, [<<"abc">>]},
-                {trie, {trie_edge, {[], [<<"abc">>]}, <<"xyz">>}, [<<"abc">>, <<"xyz">>]}
+                ]}
             ],
-            ets:tab2list(vmq_redis_trie)
+            lists:usort(ets:tab2list(vmq_redis_trie))
         )
     ].
 show_complex_topics_test(_) ->

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -59,7 +59,6 @@ start_link() ->
 
 -spec fold(subscriber_id(), topic(), fun(), any()) -> any().
 fold({MP, _} = SubscriberId, Topic, FoldFun, Acc) when is_list(Topic) ->
-    lager:info("Match MP ~p Topic: ~p", [MP, Topic]),
     MatchedTopics = [Topic | match(MP, Topic)],
     case fold_matched_topics(MP, MatchedTopics, []) of
         [] ->

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -36,7 +36,6 @@
 
 -record(state, {status = init}).
 -record(trie, {edge, node_id}).
--record(trie_node, {node_id, edge_count = 0, topic, traversal_count = 0}).
 -record(trie_edge, {node_id, word}).
 
 %%%===================================================================

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -219,7 +219,9 @@ get_complex_topics() ->
         vmq_topic:unword(T)
      || T <- ets:select(vmq_redis_trie_node, [
             {
-                #trie_node{node_id = {"", '$1'}, topic = '$1', edge_count = 0, traversal_count = 1},
+                #trie_node{
+                    node_id = {"", '$1'}, topic = '$1', edge_count = '_', traversal_count = '_'
+                },
                 [{'=/=', '$1', undefined}],
                 ['$1']
             }

--- a/apps/vmq_server/src/vmq_reg_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_trie.erl
@@ -45,7 +45,6 @@
 }).
 
 -record(trie, {edge, node_id}).
--record(trie_node, {node_id, edge_count = 0, topic}).
 -record(trie_edge, {node_id, word}).
 
 %%%===================================================================

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -18,7 +18,7 @@
 -type subscription() :: {topic(), subinfo()}.
 -define(INTERNAL_CLIENT_ID, '$vmq_internal_client_id').
 
--record(trie_node, {node_id, edge_count = 0, topic, traversal_count = 0}).
+-record(trie_node, {node_id, edge_count = 0, topic}).
 
 %% These reason codes are used internally within vernemq and are not
 %% *real* MQTT reason codes.

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -18,6 +18,8 @@
 -type subscription() :: {topic(), subinfo()}.
 -define(INTERNAL_CLIENT_ID, '$vmq_internal_client_id').
 
+-record(trie_node, {node_id, edge_count = 0, topic, traversal_count = 0}).
+
 %% These reason codes are used internally within vernemq and are not
 %% *real* MQTT reason codes.
 -define(DISCONNECT_KEEP_ALIVE, disconnect_keep_alive).


### PR DESCRIPTION
## Proposed Changes
Fix the adding and deleting complex topic methods to maintain the trie.
The deletion process doesn't check for other complex topics with a similar path, which results in the deletion of the entire path and causes messages to not be routed to other whitelisted topics.

Fix the subscription on sub-topics that are not explicitly whitelisted but are part of whitelisted topics.
only allow subscriptions on explicitly whitelisted complex topics. And show the individual explicitly whitelisted topic in vmq-admin preview.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue complex topic removal bug disrupting trie)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)
