### PR TITLE
fix: delete aged entries from parsed acl tables

### DIFF
--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -529,7 +529,7 @@ age_entries(T) ->
 del_aged_entries() ->
     lists:foreach(fun del_aged_entries/1, ?TABLES).
 del_aged_entries(T) ->
-    ets:match_delete(T, {'_', 2}).
+    ets:match_delete(T, {'_', 2, '_'}).
 
 iterate(T, Fun) ->
     iterate(T, Fun, ets:first(T)).
@@ -616,6 +616,7 @@ check_rid(Claims, UserName) ->
 acl_test_() ->
     [
         {"Simple ACL Test - vmq_reg_trie", ?setup(fun simple_acl/1)},
+        {"Simple ACL Test - Delete aged acl test", ?setup(fun delete_aged_acl_test/1)},
         {"Simple ACL Test - vmq_reg_redis_trie",
             {setup, fun setup_vmq_reg_redis_trie/0, fun teardown/1, fun simple_acl/1}}
     ].
@@ -952,6 +953,61 @@ simple_acl(_) ->
         ?_assertEqual(
             {<<"a/b ">>, <<"a">>},
             split_topic_label(<<"a/b label a b\n">>)
+        )
+    ].
+delete_aged_acl_test(_) ->
+    ACL = [
+        <<"topic a/b/c label abc\n">>,
+        <<"user test\n">>,
+        <<"topic a/b/c/# label simple_read_write\n">>,
+        <<"pattern read a/%m/%u/%c label pattern_read\n">>,
+        <<"pattern write a/%m/%u/%c\n">>,
+        <<"token read example/%(c, :, 3) label token_read\n">>,
+        <<"token write a/b/%( c  , :, 3)/+ label token_write">>
+    ],
+    load_from_list(ACL),
+    NewACL = [
+        <<"topic a/b/d label abd\n">>,
+        <<"user test\n">>,
+        <<"topic a/b/d/# label simple_read_write\n">>,
+        <<"pattern read b/%m/%u/%clabel pattern_read\n">>,
+        <<"pattern write b/%m/%u/%c\n">>,
+        <<"token read example_acl/%(c, :, 3) label token_read\n">>,
+        <<"token write a/c/%( c  , :, 3)/+ label token_write">>
+    ],
+    load_from_list(NewACL),
+    [
+        ?_assertEqual(
+            [],
+            ets:match(vmq_enhanced_auth_acl_read_pattern, {'_', 2, '$1'})
+        ),
+        ?_assertEqual(
+            [],
+            ets:match(vmq_enhanced_auth_acl_write_pattern, {'_', 2, '$1'})
+        ),
+        ?_assertEqual(
+            [],
+            ets:match(vmq_enhanced_auth_acl_read_all, {'_', 2, '$1'})
+        ),
+        ?_assertEqual(
+            [],
+            ets:match(vmq_enhanced_auth_acl_write_all, {'_', 2, '$1'})
+        ),
+        ?_assertEqual(
+            [],
+            ets:match(vmq_enhanced_auth_acl_read_user, {'_', 2, '$1'})
+        ),
+        ?_assertEqual(
+            [],
+            ets:match(vmq_enhanced_auth_acl_write_user, {'_', 2, '$1'})
+        ),
+        ?_assertEqual(
+            [],
+            ets:match(vmq_enhanced_auth_acl_read_token, {'_', 2, '$1'})
+        ),
+        ?_assertEqual(
+            [],
+            ets:match(vmq_enhanced_auth_acl_write_token, {'_', 2, '$1'})
         )
     ].
 -endif.


### PR DESCRIPTION
## Proposed Changes
This pull request will resolve an issue where old ACL entries are not removed from the ETS table despite being deleted from the file.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
