### PR TITLE
feat: add version metrics from vmq acl and trie configs

### DIFF
--- a/apps/vmq_commons/src/vmq_util.erl
+++ b/apps/vmq_commons/src/vmq_util.erl
@@ -39,7 +39,7 @@ set_interval(Interval, Pid) ->
             {IinMs, NTRef}
     end.
 
--spec extract_version(BinaryData :: binary()) -> string() | atom() | {error, any()}.
+-spec extract_version(BinaryData :: binary()) -> string() | nomatch | {error, any()}.
 extract_version(File) ->
     case file:read_file(File) of
         {ok, BinaryData} when byte_size(BinaryData) > 0 ->

--- a/apps/vmq_commons/src/vmq_util.erl
+++ b/apps/vmq_commons/src/vmq_util.erl
@@ -11,7 +11,8 @@
 -export([
     ts/0,
     timed_measurement/4,
-    set_interval/2
+    set_interval/2,
+    extract_version/1
 ]).
 
 ts() ->
@@ -36,4 +37,19 @@ set_interval(Interval, Pid) ->
             IinMs = abs(I * 1000),
             NTRef = erlang:send_after(IinMs, Pid, reload),
             {IinMs, NTRef}
+    end.
+
+-spec extract_version(BinaryData :: binary()) -> string() | atom() | {error, any()}.
+extract_version(File) ->
+    case file:read_file(File) of
+        {ok, BinaryData} when byte_size(BinaryData) > 0 ->
+            Line = hd(string:tokens(binary_to_list(BinaryData), "\n")),
+            case re:run(Line, "#\\s*(v\\d+\\.\\d+\\.\\d+)", [{capture, [1], list}]) of
+                {match, [Version]} -> Version;
+                nomatch -> nomatch
+            end;
+        {ok, _} ->
+            nomatch;
+        {error, Reason} ->
+            {error, Reason}
     end.

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -213,10 +213,9 @@ init() ->
 set_acl_version_metrics(File) ->
     case vmq_util:extract_version(File) of
         Version when is_list(Version) ->
-            vmq_metrics:update_config_version_metric({acl_version, [{version, Version}]});
+            vmq_metrics:update_config_version_metric(acl_version, Version);
         nomatch ->
-            vmq_metrics:update_config_version_metric({acl_version, [{version, "N/A"}]}),
-            error_logger:error_msg("no valid acl version found in the file ~p", [File]);
+            vmq_metrics:update_config_version_metric(acl_version, "N/A");
         {error, Reason} ->
             error_logger:error_msg("can't load acl file ~p due to ~p", [File, Reason]),
             ok

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.erl
@@ -26,7 +26,8 @@
     init/0,
     load_from_file/1,
     load_from_list/1,
-    check/5
+    check/5,
+    set_acl_version_metrics/1
 ]).
 
 -export([
@@ -208,6 +209,18 @@ init() ->
         end,
         ?TABLES
     ).
+
+set_acl_version_metrics(File) ->
+    case vmq_util:extract_version(File) of
+        Version when is_list(Version) ->
+            vmq_metrics:update_config_version_metric({acl_version, [{version, Version}]});
+        nomatch ->
+            vmq_metrics:update_config_version_metric({acl_version, [{version, "N/A"}]}),
+            error_logger:error_msg("no valid acl version found in the file ~p", [File]);
+        {error, Reason} ->
+            error_logger:error_msg("can't load acl file ~p due to ~p", [File, Reason]),
+            ok
+    end.
 
 load_from_file(File) ->
     case file:open(File, [read, binary]) of

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth_reloader.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth_reloader.erl
@@ -113,6 +113,7 @@ handle_cast(_Msg, State) ->
 %%--------------------------------------------------------------------
 handle_info(reload, #state{file = File, interval = Interval} = State) ->
     ok = vmq_enhanced_auth:load_from_file(File),
+    vmq_enhanced_auth:set_acl_version_metrics(File),
     erlang:send_after(Interval, self(), reload),
     {noreply, State}.
 
@@ -153,5 +154,6 @@ init_state(State) ->
     {ok, Interval} = application:get_env(?APP, interval),
     ok = vmq_enhanced_auth:init(),
     ok = vmq_enhanced_auth:load_from_file(File),
+    vmq_enhanced_auth:set_acl_version_metrics(File),
     {NewI, NewTRef} = vmq_util:set_interval(Interval, self()),
     State#state{file = File, interval = NewI, timer = NewTRef}.

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -103,7 +103,7 @@
 
     incr_events_sampled/2,
     incr_events_dropped/2,
-    update_config_version_metric/1
+    update_config_version_metric/2
 ]).
 
 -export([
@@ -686,15 +686,15 @@ config_version_metrics() ->
     ).
 
 -spec update_config_version_metric(
-    Metric :: {acl_version | complex_trie_version, Labels :: [{atom(), list()}]}
+    MetricName :: acl_version | complex_trie_version, Version :: list()
 ) -> ok.
-update_config_version_metric(Metric) ->
+update_config_version_metric(MetricName, Version) ->
+    Metric = {MetricName, [{version, Version}]},
     case ets:lookup(?CONFIG_VERION_TABLE, Metric) of
         [_] ->
             ok;
         _ ->
             try
-                {MetricName, _} = Metric,
                 ets:match_delete(?CONFIG_VERION_TABLE, {{MetricName, '_'}, 1}),
                 ets:insert_new(?CONFIG_VERION_TABLE, {Metric, 1})
             catch

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -102,7 +102,8 @@
     incr_shared_subscription_group_publish_attempt_failed/0,
 
     incr_events_sampled/2,
-    incr_events_dropped/2
+    incr_events_dropped/2,
+    update_config_version_metric/1
 ]).
 
 -export([
@@ -133,6 +134,7 @@
 -define(TIMER_TABLE, vmq_metrics_timers).
 -define(TOPIC_LABEL_TABLE, topic_labels).
 -define(EVENTS_SAMPLING_TABLE, vmq_metrics_events_sampling).
+-define(CONFIG_VERION_TABLE, config_version_table).
 
 -record(state, {
     info = #{}
@@ -434,13 +436,14 @@ metrics(Opts) ->
     {HistogramMetricDefs, HistogramMetricValues} = histogram_metrics(),
     {TopicMetricsDefs, TopicMetricsValues} = topic_metrics(),
     {EventsSamplingMetricsDefs, EventsSamplingMetricsValues} = events_sampling_metrics(),
+    {ConfigVersionMetricsDefs, ConfigVersionMetricsValues} = config_version_metrics(),
 
     MetricDefs =
         metric_defs() ++ PluggableMetricDefs ++ HistogramMetricDefs ++ TopicMetricsDefs ++
-            EventsSamplingMetricsDefs,
+            EventsSamplingMetricsDefs ++ ConfigVersionMetricsDefs,
     MetricValues =
         metric_values() ++ PluggableMetricValues ++ HistogramMetricValues ++ TopicMetricsValues ++
-            EventsSamplingMetricsValues,
+            EventsSamplingMetricsValues ++ ConfigVersionMetricsValues,
 
     %% Create id->metric def map
     IdDef = lists:foldl(
@@ -666,6 +669,40 @@ incr_matched_topic(Name, Type, Qos) ->
         ]}
     ).
 
+config_version_metric_defs() ->
+    {Defs, _} = config_version_metrics(),
+    Defs.
+
+config_version_metrics() ->
+    ets:foldl(
+        fun({Metric, TotalCount}, {DefsAcc, ValsAcc}) ->
+            {UniqueId, MetricName, Description, Labels} = config_version_metric_name(Metric),
+            {[m(gauge, Labels, UniqueId, MetricName, Description) | DefsAcc], [
+                {UniqueId, TotalCount} | ValsAcc
+            ]}
+        end,
+        {[], []},
+        ?CONFIG_VERION_TABLE
+    ).
+
+-spec update_config_version_metric(
+    Metric :: {acl_version | complex_trie_version, Labels :: [{atom(), list()}]}
+) -> ok.
+update_config_version_metric(Metric) ->
+    case ets:lookup(?CONFIG_VERION_TABLE, Metric) of
+        [_] ->
+            ok;
+        _ ->
+            try
+                {MetricName, _} = Metric,
+                ets:match_delete(?CONFIG_VERION_TABLE, {{MetricName, '_'}, 1}),
+                ets:insert_new(?CONFIG_VERION_TABLE, {Metric, 1})
+            catch
+                _:_ ->
+                    lager:warning("couldn't initialize tables", [])
+            end
+    end.
+
 %%--------------------------------------------------------------------
 %% @doc
 %% Starts the server
@@ -704,7 +741,7 @@ get_label_info() ->
             end,
             #{},
             metric_defs() ++ pluggable_metric_defs() ++ histogram_metric_defs() ++
-                topic_metric_defs() ++ events_sampling_metric_defs()
+                topic_metric_defs() ++ events_sampling_metric_defs() ++ config_version_metric_defs()
         ),
     maps:to_list(LabelInfo).
 
@@ -744,6 +781,7 @@ init([]) ->
     ets:new(?TIMER_TABLE, [named_table, public, {write_concurrency, true}]),
     ets:new(?TOPIC_LABEL_TABLE, [named_table, public, {write_concurrency, true}]),
     ets:new(?EVENTS_SAMPLING_TABLE, [named_table, public, {write_concurrency, true}]),
+    ets:new(?CONFIG_VERION_TABLE, [named_table, public, {write_concurrency, true}]),
 
     %% only alloc a new atomics array if one doesn't already exist!
     case catch persistent_term:get(?MODULE) of
@@ -2937,3 +2975,7 @@ events_sampled_metric_name(H, C, SDType) ->
         "The number of events " ++ SDType ++ " due to sampling enabled."
     ),
     {[Name | Labels], Name, Description, Labels}.
+
+config_version_metric_name({MetricName, Labels}) ->
+    Description = list_to_binary("The current version of the config file."),
+    {[MetricName | Labels], MetricName, Description, Labels}.

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -136,6 +136,18 @@ fold_local_shared_subscriber_info(
         SubscriberId, SubscribersList, FoldFun, FoldFun(SubscriberInfo, SubscriberId, Acc)
     ).
 
+set_complex_trie_version_metrics(File) ->
+    case vmq_util:extract_version(File) of
+        Version when is_list(Version) ->
+            vmq_metrics:update_config_version_metric({complex_trie_version, [{version, Version}]});
+        nomatch ->
+            vmq_metrics:update_config_version_metric({complex_trie_version, [{version, "N/A"}]}),
+            lager:error("no valid trie version found in the file ~p", [File]);
+        {error, Reason} ->
+            lager:error("can't load complex topics trie acl file ~p due to ~p", [File, Reason]),
+            ok
+    end.
+
 load_from_file(File) ->
     case file:read_file(File) of
         {ok, BinaryData} ->
@@ -288,6 +300,7 @@ handle_info(
     reload, #state{file = File, interval = Interval} = State
 ) ->
     ok = load_from_file(File),
+    set_complex_trie_version_metrics(File),
     erlang:send_after(Interval, self(), reload),
     {noreply, State}.
 
@@ -324,6 +337,7 @@ init_state(State) ->
     {ok, Interval} = application:get_env(vmq_server, complex_trie_reload_interval),
     {NewI, NewTRef} = vmq_util:set_interval(Interval, self()),
     ok = load_from_file(File),
+    set_complex_trie_version_metrics(File),
     State#state{status = ready, interval = NewI, timer = NewTRef, file = File}.
 
 match(MP, Topic) when is_list(MP) and is_list(Topic) ->
@@ -416,6 +430,8 @@ trie_delete_path(MP, [{Node, Word, _} | RestPath]) ->
     end.
 
 -spec parse_topic_list(Topics :: [string()]) -> [[binary()]].
+parse_topic_list(["# " ++ _ | Topics]) ->
+    parse_topic_list(Topics);
 parse_topic_list(Topics) ->
     lists:foldl(
         fun(T, Acc) ->

--- a/apps/vmq_server/src/vmq_reg_redis_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_redis_trie.erl
@@ -139,10 +139,9 @@ fold_local_shared_subscriber_info(
 set_complex_trie_version_metrics(File) ->
     case vmq_util:extract_version(File) of
         Version when is_list(Version) ->
-            vmq_metrics:update_config_version_metric({complex_trie_version, [{version, Version}]});
+            vmq_metrics:update_config_version_metric(complex_trie_version, Version);
         nomatch ->
-            vmq_metrics:update_config_version_metric({complex_trie_version, [{version, "N/A"}]}),
-            lager:error("no valid trie version found in the file ~p", [File]);
+            vmq_metrics:update_config_version_metric(complex_trie_version, "N/A");
         {error, Reason} ->
             lager:error("can't load complex topics trie acl file ~p due to ~p", [File, Reason]),
             ok


### PR DESCRIPTION
## Proposed Changes
This change will extract the version from the `vmq.acl` and `vmq.trie` file and export them as metrics to Prometheus. 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging