### PR TITLE
feat: add metrics for client connected over web-socket

### DIFF
--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -25,6 +25,8 @@
     incr_socket_open/0,
     incr_socket_close/0,
     incr_socket_close_timeout/0,
+    incr_web_socket_open/0,
+    incr_web_socket_close/0,
     incr_socket_error/0,
     incr_bytes_received/1,
     incr_bytes_sent/1,
@@ -159,6 +161,12 @@ incr_socket_close() ->
 
 incr_socket_close_timeout() ->
     incr_item(?METRIC_SOCKET_CLOSE_TIMEOUT, 1).
+
+incr_web_socket_open() ->
+    incr_item(?METRIC_WEB_SOCKET_OPEN, 1).
+
+incr_web_socket_close() ->
+    incr_item(?METRIC_WEB_SOCKET_CLOSE, 1).
 
 incr_socket_error() ->
     incr_item(?METRIC_SOCKET_ERROR, 1).
@@ -1287,6 +1295,20 @@ counter_entries_def() ->
             socket_close,
             socket_close,
             <<"The number of times an MQTT socket has been closed.">>
+        ),
+        m(
+            counter,
+            [],
+            web_socket_open,
+            web_socket_open,
+            <<"The number of times an MQTT connection over web-socket has been opened.">>
+        ),
+        m(
+            counter,
+            [],
+            web_socket_close,
+            web_socket_close,
+            <<"The number of times an MQTT connection over web-socket has been closed.">>
         ),
         m(
             counter,
@@ -2891,7 +2913,9 @@ met2idx({?MQTT_DISONNECT, ?REASON_UNEXPECTED_FRAME_TYPE}) -> 346;
 met2idx({?MQTT_DISONNECT, ?REASON_EXIT_SIGNAL_RECEIVED}) -> 347;
 met2idx({?MQTT_DISONNECT, ?REASON_TCP_CLOSED}) -> 348;
 met2idx({?MQTT_DISONNECT, ?REASON_UNSPECIFIED}) -> 349;
-met2idx(shared_subscription_group_publish_attempt_failed) -> 350.
+met2idx(shared_subscription_group_publish_attempt_failed) -> 350;
+met2idx(?METRIC_WEB_SOCKET_OPEN) -> 351;
+met2idx(?METRIC_WEB_SOCKET_CLOSE) -> 352.
 
 -ifdef(TEST).
 clear_stored_rates() ->

--- a/apps/vmq_server/src/vmq_metrics.hrl
+++ b/apps/vmq_server/src/vmq_metrics.hrl
@@ -108,6 +108,8 @@
 -define(METRIC_SOCKET_OPEN, socket_open).
 -define(METRIC_SOCKET_CLOSE, socket_close).
 -define(METRIC_SOCKET_CLOSE_TIMEOUT, socket_close_timeout).
+-define(METRIC_WEB_SOCKET_OPEN, web_socket_open).
+-define(METRIC_WEB_SOCKET_CLOSE, web_socket_close).
 -define(METRIC_SOCKET_ERROR, socket_error).
 -define(METRIC_BYTES_RECEIVED, bytes_received).
 -define(METRIC_BYTES_SENT, bytes_sent).

--- a/apps/vmq_server/src/vmq_websocket.erl
+++ b/apps/vmq_server/src/vmq_websocket.erl
@@ -81,9 +81,11 @@ init(Req, Opts) ->
 
 websocket_init({error, unsupported_protocol}) ->
     _ = vmq_metrics:incr_socket_open(),
+    _ = vmq_metrics:incr_web_socket_open(),
     {stop, #state{fsm_state = terminated}};
 websocket_init(State) ->
     _ = vmq_metrics:incr_socket_open(),
+    _ = vmq_metrics:incr_web_socket_open(),
     {ok, State, hibernate}.
 
 websocket_handle(_, #state{fsm_state = terminated} = State) ->
@@ -141,10 +143,12 @@ websocket_info(_Info, State) ->
 
 terminate(_Reason, _Req, #state{fsm_state = terminated}) ->
     _ = vmq_metrics:incr_socket_close(),
+    _ = vmq_metrics:incr_web_socket_close(),
     ok;
 terminate(_Reason, _Req, #state{fsm_mod = FsmMod, fsm_state = FsmState}) ->
     _ = FsmMod:msg_in({disconnect, ?NORMAL_DISCONNECT}, FsmState),
     _ = vmq_metrics:incr_socket_close(),
+    _ = vmq_metrics:incr_web_socket_close(),
     ok.
 
 %% Internal


### PR DESCRIPTION
## Proposed Changes
The current connected client metrics shows all the connections over `TCP` and `WS`.
This MR will add metrics showing number connected client over `WS`.

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist
- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
