### PR TITLE
Feat/add offline store message flag to deliver events

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity.app.src
+++ b/apps/vmq_diversity/src/vmq_diversity.app.src
@@ -39,7 +39,7 @@
             {vmq_diversity_plugin, on_subscribe, 3, []},
             {vmq_diversity_plugin, on_unsubscribe, 3, []},
             {vmq_diversity_plugin, on_deliver, 8, []},
-            {vmq_diversity_plugin, on_delivery_complete, 7, []},
+            {vmq_diversity_plugin, on_delivery_complete, 8, []},
 
             {vmq_diversity_plugin, auth_on_register_m5, 6, []},
             {vmq_diversity_plugin, auth_on_publish_m5, 7, []},

--- a/apps/vmq_diversity/src/vmq_diversity.app.src
+++ b/apps/vmq_diversity/src/vmq_diversity.app.src
@@ -38,7 +38,7 @@
             {vmq_diversity_plugin, on_publish, 7, []},
             {vmq_diversity_plugin, on_subscribe, 3, []},
             {vmq_diversity_plugin, on_unsubscribe, 3, []},
-            {vmq_diversity_plugin, on_deliver, 7, []},
+            {vmq_diversity_plugin, on_deliver, 8, []},
             {vmq_diversity_plugin, on_delivery_complete, 7, []},
 
             {vmq_diversity_plugin, auth_on_register_m5, 6, []},

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -48,13 +48,13 @@
     on_publish/7,
     on_subscribe/3,
     on_unsubscribe/3,
-    on_deliver/7,
+    on_deliver/8,
     on_offline_message/5,
     on_client_wakeup/1,
     on_client_offline/2,
     on_client_gone/2,
     on_session_expired/1,
-    on_delivery_complete/7,
+    on_delivery_complete/8,
     auth_on_register_m5/6,
     on_register_m5/4,
     auth_on_publish_m5/7,
@@ -582,7 +582,7 @@ on_unsubscribe(UserName, SubscriberId, Topics) ->
             ])
     end.
 
-on_deliver(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _) ->
+on_deliver(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _, _) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     all_till_ok(on_deliver, [
         {username, nilify(UserName)},
@@ -594,7 +594,7 @@ on_deliver(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _) ->
         {retain, IsRetain}
     ]).
 
-on_delivery_complete(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _) ->
+on_delivery_complete(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _, _) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     all(on_delivery_complete, [
         {username, nilify(UserName)},

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -129,7 +129,7 @@ on_unsubscribe_test(_) ->
 
 on_deliver_test(_) ->
     ok = vmq_plugin:all_till_ok(on_deliver,
-                                [username(), allowed_subscriber_id(), 1, topic(), payload(), false, matched_acl()]).
+                                [username(), allowed_subscriber_id(), 1, topic(), payload(), false, matched_acl(), false]).
 
 on_offline_message_test(_) ->
     [next] = vmq_plugin:all(on_offline_message, [allowed_subscriber_id(), 2,

--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar.app.src
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar.app.src
@@ -20,12 +20,12 @@
             {vmq_events_sidecar_plugin, on_publish, 7, []},
             {vmq_events_sidecar_plugin, on_subscribe, 3, []},
             {vmq_events_sidecar_plugin, on_unsubscribe, 3, []},
-            {vmq_events_sidecar_plugin, on_deliver, 7, []},
+            {vmq_events_sidecar_plugin, on_deliver, 8, []},
             {vmq_events_sidecar_plugin, on_offline_message, 5, []},
             {vmq_events_sidecar_plugin, on_client_wakeup, 1, []},
             {vmq_events_sidecar_plugin, on_client_offline, 2, []},
             {vmq_events_sidecar_plugin, on_session_expired, 1, []},
-            {vmq_events_sidecar_plugin, on_delivery_complete, 7, []},
+            {vmq_events_sidecar_plugin, on_delivery_complete, 8, []},
             {vmq_events_sidecar_plugin, on_client_gone, 2, []},
             {vmq_events_sidecar_plugin, on_message_drop, 3, []}
         ]}

--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar_format.erl
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar_format.erl
@@ -103,9 +103,11 @@ encode({on_unsubscribe, Timestamp, {MP, ClientId, UserName, Topics}}) ->
     );
 encode(
     {on_deliver, Timestamp,
-        {MP, ClientId, UserName, QoS, Topic, Payload, IsRetain, #matched_acl{
-            name = Name, pattern = Pattern
-        }}}
+        {MP, ClientId, UserName, QoS, Topic, Payload, IsRetain,
+            #matched_acl{
+                name = Name, pattern = Pattern
+            },
+            Persisted}}
 ) ->
     encode_envelope(
         "OnDeliver",
@@ -120,14 +122,17 @@ encode(
             timestamp = convert_timestamp(Timestamp),
             matched_acl = #'eventssidecar.v1.MatchedACL'{
                 name = Name, pattern = Pattern
-            }
+            },
+            persisted = Persisted
         })
     );
 encode(
     {on_delivery_complete, Timestamp,
-        {MP, ClientId, UserName, QoS, Topic, Payload, IsRetain, #matched_acl{
-            name = Name, pattern = Pattern
-        }}}
+        {MP, ClientId, UserName, QoS, Topic, Payload, IsRetain,
+            #matched_acl{
+                name = Name, pattern = Pattern
+            },
+            Persisted}}
 ) ->
     encode_envelope(
         "OnDeliveryComplete",
@@ -142,7 +147,8 @@ encode(
             timestamp = convert_timestamp(Timestamp),
             matched_acl = #'eventssidecar.v1.MatchedACL'{
                 name = Name, pattern = Pattern
-            }
+            },
+            persisted = Persisted
         })
     );
 encode({on_offline_message, Timestamp, {MP, ClientId, QoS, Topic, Payload, IsRetain}}) ->

--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar_format.erl
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar_format.erl
@@ -104,10 +104,7 @@ encode({on_unsubscribe, Timestamp, {MP, ClientId, UserName, Topics}}) ->
 encode(
     {on_deliver, Timestamp,
         {MP, ClientId, UserName, QoS, Topic, Payload, IsRetain,
-            #matched_acl{
-                name = Name, pattern = Pattern
-            },
-            Persisted}}
+            #matched_acl{name = Name, pattern = Pattern}, Persisted}}
 ) ->
     encode_envelope(
         "OnDeliver",
@@ -129,10 +126,7 @@ encode(
 encode(
     {on_delivery_complete, Timestamp,
         {MP, ClientId, UserName, QoS, Topic, Payload, IsRetain,
-            #matched_acl{
-                name = Name, pattern = Pattern
-            },
-            Persisted}}
+            #matched_acl{name = Name, pattern = Pattern}, Persisted}}
 ) ->
     encode_envelope(
         "OnDeliveryComplete",

--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar_plugin.erl
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar_plugin.erl
@@ -25,13 +25,13 @@
     on_publish/7,
     on_subscribe/3,
     on_unsubscribe/3,
-    on_deliver/7,
+    on_deliver/8,
     on_offline_message/5,
     on_client_wakeup/1,
     on_client_offline/2,
     on_client_gone/2,
     on_session_expired/1,
-    on_delivery_complete/7,
+    on_delivery_complete/8,
     on_message_drop/3
 ]).
 
@@ -292,27 +292,38 @@ on_unsubscribe(UserName, SubscriberId, Topics) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     send_event(on_unsubscribe, {MP, ClientId, normalise(UserName), [unword(T) || T <- Topics]}).
 
--spec on_deliver(username(), subscriber_id(), qos(), topic(), payload(), flag(), matched_acl()) ->
+-spec on_deliver(
+    username(), subscriber_id(), qos(), topic(), payload(), flag(), matched_acl(), flag()
+) ->
     'next' | 'ok' | {'ok', payload() | [on_deliver_hook:msg_modifier()]}.
 on_deliver(
-    UserName, SubscriberId, QoS, Topic, Payload, IsRetain, #matched_acl{name = ACL} = MatchedAcl
+    UserName,
+    SubscriberId,
+    QoS,
+    Topic,
+    Payload,
+    IsRetain,
+    #matched_acl{name = ACL} = MatchedAcl,
+    Persisted
 ) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     send_event(
         on_deliver,
-        {MP, ClientId, normalise(UserName), QoS, unword(Topic), Payload, IsRetain, MatchedAcl},
+        {MP, ClientId, normalise(UserName), QoS, unword(Topic), Payload, IsRetain, MatchedAcl,
+            Persisted},
         ACL
     ).
 
 -spec on_delivery_complete(
-    username(), subscriber_id(), qos(), topic(), payload(), flag(), matched_acl()
+    username(), subscriber_id(), qos(), topic(), payload(), flag(), matched_acl(), flag()
 ) ->
     'next'.
-on_delivery_complete(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, MatchedAcl) ->
+on_delivery_complete(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, MatchedAcl, Persisted) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     send_event(
         on_delivery_complete,
-        {MP, ClientId, normalise(UserName), QoS, unword(Topic), Payload, IsRetain, MatchedAcl}
+        {MP, ClientId, normalise(UserName), QoS, unword(Topic), Payload, IsRetain, MatchedAcl,
+            Persisted}
     ).
 
 -spec on_offline_message(subscriber_id(), qos(), topic(), payload(), flag()) -> 'next'.

--- a/apps/vmq_events_sidecar/test/events_sidecar_handler.erl
+++ b/apps/vmq_events_sidecar/test/events_sidecar_handler.erl
@@ -143,7 +143,8 @@ on_deliver(#'eventssidecar.v1.OnDeliver'{username = BinPid,
              topic = ?TOPIC,
              payload = ?PAYLOAD,
              is_retain = false,
-             matched_acl = #'eventssidecar.v1.MatchedACL'{name = ?LABEL, pattern = ?PATTERN}
+             matched_acl = #'eventssidecar.v1.MatchedACL'{name = ?LABEL, pattern = ?PATTERN},
+             persisted = true
              }) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_deliver_ok.
@@ -155,7 +156,8 @@ on_delivery_complete(#'eventssidecar.v1.OnDeliveryComplete'{username = BinPid,
                        topic = ?TOPIC,
                        payload = ?PAYLOAD,
                        is_retain = false,
-                       matched_acl = #'eventssidecar.v1.MatchedACL'{name = ?LABEL, pattern = ?PATTERN}}) ->
+                       matched_acl = #'eventssidecar.v1.MatchedACL'{name = ?LABEL, pattern = ?PATTERN},
+                       persisted = true}) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_delivery_complete_ok.
 

--- a/apps/vmq_events_sidecar/test/vmq_events_sidecar_SUITE.erl
+++ b/apps/vmq_events_sidecar/test/vmq_events_sidecar_SUITE.erl
@@ -110,14 +110,14 @@ on_deliver_test(_) ->
     enable_hook(on_deliver),
     Self = pid_to_bin(self()),
     ok = vmq_plugin:all_till_ok(on_deliver,
-                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #matched_acl{name = ?LABEL, pattern = ?PATTERN}]),
+                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #matched_acl{name = ?LABEL, pattern = ?PATTERN}, true]),
     ok = exp_response(on_deliver_ok),
     disable_hook(on_deliver).
 
 on_delivery_complete_test(_) ->
   enable_hook(on_delivery_complete),
   Self = pid_to_bin(self()),
-  [ok] = vmq_plugin:all(on_delivery_complete,[Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #matched_acl{name = ?LABEL, pattern = ?PATTERN}]),
+  [ok] = vmq_plugin:all(on_delivery_complete,[Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #matched_acl{name = ?LABEL, pattern = ?PATTERN}, true]),
   ok = exp_response(on_delivery_complete_ok),
   disable_hook(on_delivery_complete).
 

--- a/apps/vmq_proto/include/on_deliver_pb.hrl
+++ b/apps/vmq_proto/include/on_deliver_pb.hrl
@@ -28,7 +28,9 @@
         % = 8, optional
         payload = <<>> :: iodata() | undefined,
         % = 9, optional
-        matched_acl = undefined :: on_deliver_pb:'eventssidecar.v1.MatchedACL'() | undefined
+        matched_acl = undefined :: on_deliver_pb:'eventssidecar.v1.MatchedACL'() | undefined,
+        % = 10, optional
+        persisted = false :: boolean() | 0 | 1 | undefined
     }
 ).
 -endif.

--- a/apps/vmq_proto/include/on_delivery_complete_pb.hrl
+++ b/apps/vmq_proto/include/on_delivery_complete_pb.hrl
@@ -29,7 +29,9 @@
         payload = <<>> :: iodata() | undefined,
         % = 9, optional
         matched_acl = undefined ::
-            on_delivery_complete_pb:'eventssidecar.v1.MatchedACL'() | undefined
+            on_delivery_complete_pb:'eventssidecar.v1.MatchedACL'() | undefined,
+        % = 10, optional
+        persisted = false :: boolean() | 0 | 1 | undefined
     }
 ).
 -endif.

--- a/apps/vmq_proto/proto/on_deliver.proto
+++ b/apps/vmq_proto/proto/on_deliver.proto
@@ -17,4 +17,5 @@ message OnDeliver {
   bool is_retain = 7;
   bytes payload = 8;
   MatchedACL matched_acl = 9;
+  bool persisted = 10;
 }

--- a/apps/vmq_proto/proto/on_delivery_complete.proto
+++ b/apps/vmq_proto/proto/on_delivery_complete.proto
@@ -17,4 +17,5 @@ message OnDeliveryComplete {
   bool is_retain = 7;
   bytes payload = 8;
   MatchedACL matched_acl = 9;
+  bool persisted = 10;
 }

--- a/apps/vmq_proto/src/on_deliver_pb.erl
+++ b/apps/vmq_proto/src/on_deliver_pb.erl
@@ -108,7 +108,8 @@ encode_msg(Msg, MsgName, Opts) ->
         qos = F6,
         is_retain = F7,
         payload = F8,
-        matched_acl = F9
+        matched_acl = F9,
+        persisted = F10
     },
     Bin,
     TrUserData
@@ -221,19 +222,32 @@ encode_msg(Msg, MsgName, Opts) ->
                     end
                 end
         end,
+    B9 =
+        if
+            F9 == undefined ->
+                B8;
+            true ->
+                begin
+                    TrF9 = id(F9, TrUserData),
+                    if
+                        TrF9 =:= undefined ->
+                            B8;
+                        true ->
+                            'e_mfield_eventssidecar.v1.OnDeliver_matched_acl'(
+                                TrF9, <<B8/binary, 74>>, TrUserData
+                            )
+                    end
+                end
+        end,
     if
-        F9 == undefined ->
-            B8;
+        F10 == undefined ->
+            B9;
         true ->
             begin
-                TrF9 = id(F9, TrUserData),
+                TrF10 = id(F10, TrUserData),
                 if
-                    TrF9 =:= undefined ->
-                        B8;
-                    true ->
-                        'e_mfield_eventssidecar.v1.OnDeliver_matched_acl'(
-                            TrF9, <<B8/binary, 74>>, TrUserData
-                        )
+                    TrF10 =:= false -> B9;
+                    true -> e_type_bool(TrF10, <<B9/binary, 80>>, TrUserData)
                 end
             end
     end.
@@ -481,65 +495,212 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         id(false, TrUserData),
         id(<<>>, TrUserData),
         id(undefined, TrUserData),
+        id(false, TrUserData),
         TrUserData
     ).
 
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<10, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<10, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_timestamp'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<18, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<18, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_username'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<26, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<26, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_client_id'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<34, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<34, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_mountpoint'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<42, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<42, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_topic'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<48, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<48, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_qos'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<56, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<56, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_is_retain'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<66, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<66, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_payload'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<74, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<74, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliver_matched_acl'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<>>, 0, 0, _, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, _
+    <<80, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
+) ->
+    'd_field_eventssidecar.v1.OnDeliver_persisted'(
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
+    );
+'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
+    <<>>, 0, 0, _, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, _
 ) ->
     #'eventssidecar.v1.OnDeliver'{
         timestamp = F@_1,
@@ -550,13 +711,14 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         qos = F@_6,
         is_retain = F@_7,
         payload = F@_8,
-        matched_acl = F@_9
+        matched_acl = F@_9,
+        persisted = F@_10
     };
 'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-    Other, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    Other, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
 ) ->
     'dg_read_field_def_eventssidecar.v1.OnDeliver'(
-        Other, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Other, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'dg_read_field_def_eventssidecar.v1.OnDeliver'(
@@ -573,6 +735,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 32 - 7 ->
     'dg_read_field_def_eventssidecar.v1.OnDeliver'(
@@ -589,6 +752,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'dg_read_field_def_eventssidecar.v1.OnDeliver'(
@@ -605,45 +769,190 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     Key = X bsl N + Acc,
     case Key of
         10 ->
             'd_field_eventssidecar.v1.OnDeliver_timestamp'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         18 ->
             'd_field_eventssidecar.v1.OnDeliver_username'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         26 ->
             'd_field_eventssidecar.v1.OnDeliver_client_id'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         34 ->
             'd_field_eventssidecar.v1.OnDeliver_mountpoint'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         42 ->
             'd_field_eventssidecar.v1.OnDeliver_topic'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         48 ->
             'd_field_eventssidecar.v1.OnDeliver_qos'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         56 ->
             'd_field_eventssidecar.v1.OnDeliver_is_retain'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         66 ->
             'd_field_eventssidecar.v1.OnDeliver_payload'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         74 ->
             'd_field_eventssidecar.v1.OnDeliver_matched_acl'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
+            );
+        80 ->
+            'd_field_eventssidecar.v1.OnDeliver_persisted'(
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         _ ->
             case Key band 7 of
@@ -662,6 +971,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     );
                 1 ->
@@ -679,6 +989,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     );
                 2 ->
@@ -696,6 +1007,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     );
                 3 ->
@@ -713,6 +1025,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     );
                 5 ->
@@ -730,12 +1043,13 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     )
             end
     end;
 'dg_read_field_def_eventssidecar.v1.OnDeliver'(
-    <<>>, 0, 0, _, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, _
+    <<>>, 0, 0, _, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, _
 ) ->
     #'eventssidecar.v1.OnDeliver'{
         timestamp = F@_1,
@@ -746,7 +1060,8 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         qos = F@_6,
         is_retain = F@_7,
         payload = F@_8,
-        matched_acl = F@_9
+        matched_acl = F@_9,
+        persisted = F@_10
     }.
 
 'd_field_eventssidecar.v1.OnDeliver_timestamp'(
@@ -763,6 +1078,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_timestamp'(
@@ -779,6 +1095,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_timestamp'(
@@ -795,6 +1112,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -819,6 +1137,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     ).
 
@@ -836,6 +1155,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_username'(
@@ -852,6 +1172,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_username'(
@@ -868,6 +1189,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -877,7 +1199,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        RestF, 0, 0, F, F@_1, NewFValue, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, NewFValue, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliver_client_id'(
@@ -894,6 +1216,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_client_id'(
@@ -910,6 +1233,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_client_id'(
@@ -926,6 +1250,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -935,7 +1260,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        RestF, 0, 0, F, F@_1, F@_2, NewFValue, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, NewFValue, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliver_mountpoint'(
@@ -952,6 +1277,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_mountpoint'(
@@ -968,6 +1294,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_mountpoint'(
@@ -984,6 +1311,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -993,7 +1321,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, NewFValue, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, NewFValue, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliver_topic'(
@@ -1010,6 +1338,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_topic'(
@@ -1026,6 +1355,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_topic'(
@@ -1042,6 +1372,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -1051,7 +1382,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, NewFValue, F@_6, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, NewFValue, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliver_qos'(
@@ -1068,6 +1399,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_qos'(
@@ -1084,6 +1416,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_qos'(
@@ -1100,6 +1433,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = {
@@ -1110,7 +1444,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         Rest
     },
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, NewFValue, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, NewFValue, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliver_is_retain'(
@@ -1127,6 +1461,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_is_retain'(
@@ -1143,6 +1478,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_is_retain'(
@@ -1159,11 +1495,12 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     _,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = {id(X bsl N + Acc =/= 0, TrUserData), Rest},
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, NewFValue, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, NewFValue, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliver_payload'(
@@ -1180,6 +1517,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_payload'(
@@ -1196,6 +1534,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_payload'(
@@ -1212,6 +1551,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     _,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -1221,7 +1561,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, NewFValue, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, NewFValue, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliver_matched_acl'(
@@ -1238,6 +1578,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliver_matched_acl'(
@@ -1254,6 +1595,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliver_matched_acl'(
@@ -1270,6 +1612,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     Prev,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -1294,7 +1637,64 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
             Prev == undefined -> NewFValue;
             true -> 'merge_msg_eventssidecar.v1.MatchedACL'(Prev, NewFValue, TrUserData)
         end,
+        F@_10,
         TrUserData
+    ).
+
+'d_field_eventssidecar.v1.OnDeliver_persisted'(
+    <<1:1, X:7, Rest/binary>>,
+    N,
+    Acc,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
+) when N < 57 ->
+    'd_field_eventssidecar.v1.OnDeliver_persisted'(
+        Rest,
+        N + 7,
+        X bsl N + Acc,
+        F,
+        F@_1,
+        F@_2,
+        F@_3,
+        F@_4,
+        F@_5,
+        F@_6,
+        F@_7,
+        F@_8,
+        F@_9,
+        F@_10,
+        TrUserData
+    );
+'d_field_eventssidecar.v1.OnDeliver_persisted'(
+    <<0:1, X:7, Rest/binary>>,
+    N,
+    Acc,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    _,
+    TrUserData
+) ->
+    {NewFValue, RestF} = {id(X bsl N + Acc =/= 0, TrUserData), Rest},
+    'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, NewFValue, TrUserData
     ).
 
 'skip_varint_eventssidecar.v1.OnDeliver'(
@@ -1311,10 +1711,11 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     'skip_varint_eventssidecar.v1.OnDeliver'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'skip_varint_eventssidecar.v1.OnDeliver'(
     <<0:1, _:7, Rest/binary>>,
@@ -1330,10 +1731,11 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'skip_length_delimited_eventssidecar.v1.OnDeliver'(
@@ -1350,6 +1752,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'skip_length_delimited_eventssidecar.v1.OnDeliver'(
@@ -1366,6 +1769,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'skip_length_delimited_eventssidecar.v1.OnDeliver'(
@@ -1382,20 +1786,21 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     Length = X bsl N + Acc,
     <<_:Length/binary, Rest2/binary>> = Rest,
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        Rest2, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest2, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'skip_group_eventssidecar.v1.OnDeliver'(
-    Bin, _, Z2, FNum, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    Bin, _, Z2, FNum, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
 ) ->
     {_, Rest} = read_group(Bin, FNum),
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        Rest, 0, Z2, FNum, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, 0, Z2, FNum, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'skip_32_eventssidecar.v1.OnDeliver'(
@@ -1412,10 +1817,11 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'skip_64_eventssidecar.v1.OnDeliver'(
@@ -1432,10 +1838,11 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     'dfp_read_field_def_eventssidecar.v1.OnDeliver'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'decode_msg_google.protobuf.Timestamp'(Bin, TrUserData) ->
@@ -1795,7 +2202,8 @@ merge_msgs(Prev, New, MsgName, Opts) ->
         qos = PFqos,
         is_retain = PFis_retain,
         payload = PFpayload,
-        matched_acl = PFmatched_acl
+        matched_acl = PFmatched_acl,
+        persisted = PFpersisted
     },
     #'eventssidecar.v1.OnDeliver'{
         timestamp = NFtimestamp,
@@ -1806,7 +2214,8 @@ merge_msgs(Prev, New, MsgName, Opts) ->
         qos = NFqos,
         is_retain = NFis_retain,
         payload = NFpayload,
-        matched_acl = NFmatched_acl
+        matched_acl = NFmatched_acl,
+        persisted = NFpersisted
     },
     TrUserData
 ) ->
@@ -1865,6 +2274,11 @@ merge_msgs(Prev, New, MsgName, Opts) ->
                     NFmatched_acl;
                 NFmatched_acl == undefined ->
                     PFmatched_acl
+            end,
+        persisted =
+            if
+                NFpersisted =:= undefined -> PFpersisted;
+                true -> NFpersisted
             end
     }.
 
@@ -1938,7 +2352,8 @@ verify_msg(Msg, MsgName, Opts) ->
         qos = F6,
         is_retain = F7,
         payload = F8,
-        matched_acl = F9
+        matched_acl = F9,
+        persisted = F10
     },
     Path,
     TrUserData
@@ -1978,6 +2393,10 @@ verify_msg(Msg, MsgName, Opts) ->
     if
         F9 == undefined -> ok;
         true -> 'v_submsg_eventssidecar.v1.MatchedACL'(F9, [matched_acl | Path], TrUserData)
+    end,
+    if
+        F10 == undefined -> ok;
+        true -> v_type_bool(F10, [persisted | Path], TrUserData)
     end,
     ok;
 'v_msg_eventssidecar.v1.OnDeliver'(X, Path, _TrUserData) ->
@@ -2155,6 +2574,14 @@ get_msg_defs() ->
                 type = {msg, 'eventssidecar.v1.MatchedACL'},
                 occurrence = optional,
                 opts = []
+            },
+            #field{
+                name = persisted,
+                fnum = 10,
+                rnum = 11,
+                type = bool,
+                occurrence = optional,
+                opts = []
             }
         ]},
         {{msg, 'google.protobuf.Timestamp'}, [
@@ -2222,6 +2649,9 @@ find_msg_def('eventssidecar.v1.OnDeliver') ->
             type = {msg, 'eventssidecar.v1.MatchedACL'},
             occurrence = optional,
             opts = []
+        },
+        #field{
+            name = persisted, fnum = 10, rnum = 11, type = bool, occurrence = optional, opts = []
         }
     ];
 find_msg_def('google.protobuf.Timestamp') ->

--- a/apps/vmq_proto/src/on_delivery_complete_pb.erl
+++ b/apps/vmq_proto/src/on_delivery_complete_pb.erl
@@ -112,7 +112,8 @@ encode_msg(Msg, MsgName, Opts) ->
         qos = F6,
         is_retain = F7,
         payload = F8,
-        matched_acl = F9
+        matched_acl = F9,
+        persisted = F10
     },
     Bin,
     TrUserData
@@ -225,19 +226,32 @@ encode_msg(Msg, MsgName, Opts) ->
                     end
                 end
         end,
+    B9 =
+        if
+            F9 == undefined ->
+                B8;
+            true ->
+                begin
+                    TrF9 = id(F9, TrUserData),
+                    if
+                        TrF9 =:= undefined ->
+                            B8;
+                        true ->
+                            'e_mfield_eventssidecar.v1.OnDeliveryComplete_matched_acl'(
+                                TrF9, <<B8/binary, 74>>, TrUserData
+                            )
+                    end
+                end
+        end,
     if
-        F9 == undefined ->
-            B8;
+        F10 == undefined ->
+            B9;
         true ->
             begin
-                TrF9 = id(F9, TrUserData),
+                TrF10 = id(F10, TrUserData),
                 if
-                    TrF9 =:= undefined ->
-                        B8;
-                    true ->
-                        'e_mfield_eventssidecar.v1.OnDeliveryComplete_matched_acl'(
-                            TrF9, <<B8/binary, 74>>, TrUserData
-                        )
+                    TrF10 =:= false -> B9;
+                    true -> e_type_bool(TrF10, <<B9/binary, 80>>, TrUserData)
                 end
             end
     end.
@@ -485,65 +499,212 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         id(false, TrUserData),
         id(<<>>, TrUserData),
         id(undefined, TrUserData),
+        id(false, TrUserData),
         TrUserData
     ).
 
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<10, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<10, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_timestamp'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<18, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<18, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_username'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<26, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<26, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_client_id'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<34, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<34, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_mountpoint'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<42, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<42, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_topic'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<48, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<48, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_qos'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<56, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<56, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_is_retain'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<66, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<66, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_payload'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<74, Rest/binary>>, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    <<74, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
 ) ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_matched_acl'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<>>, 0, 0, _, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, _
+    <<80, Rest/binary>>,
+    Z1,
+    Z2,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
+) ->
+    'd_field_eventssidecar.v1.OnDeliveryComplete_persisted'(
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
+    );
+'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
+    <<>>, 0, 0, _, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, _
 ) ->
     #'eventssidecar.v1.OnDeliveryComplete'{
         timestamp = F@_1,
@@ -554,13 +715,14 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         qos = F@_6,
         is_retain = F@_7,
         payload = F@_8,
-        matched_acl = F@_9
+        matched_acl = F@_9,
+        persisted = F@_10
     };
 'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    Other, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    Other, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
 ) ->
     'dg_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        Other, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Other, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'dg_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
@@ -577,6 +739,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 32 - 7 ->
     'dg_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
@@ -593,6 +756,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'dg_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
@@ -609,45 +773,190 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     Key = X bsl N + Acc,
     case Key of
         10 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_timestamp'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         18 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_username'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         26 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_client_id'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         34 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_mountpoint'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         42 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_topic'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         48 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_qos'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         56 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_is_retain'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         66 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_payload'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         74 ->
             'd_field_eventssidecar.v1.OnDeliveryComplete_matched_acl'(
-                Rest, 0, 0, 0, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
+            );
+        80 ->
+            'd_field_eventssidecar.v1.OnDeliveryComplete_persisted'(
+                Rest,
+                0,
+                0,
+                0,
+                F@_1,
+                F@_2,
+                F@_3,
+                F@_4,
+                F@_5,
+                F@_6,
+                F@_7,
+                F@_8,
+                F@_9,
+                F@_10,
+                TrUserData
             );
         _ ->
             case Key band 7 of
@@ -666,6 +975,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     );
                 1 ->
@@ -683,6 +993,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     );
                 2 ->
@@ -700,6 +1011,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     );
                 3 ->
@@ -717,6 +1029,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     );
                 5 ->
@@ -734,12 +1047,13 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
                         F@_7,
                         F@_8,
                         F@_9,
+                        F@_10,
                         TrUserData
                     )
             end
     end;
 'dg_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-    <<>>, 0, 0, _, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, _
+    <<>>, 0, 0, _, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, _
 ) ->
     #'eventssidecar.v1.OnDeliveryComplete'{
         timestamp = F@_1,
@@ -750,7 +1064,8 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         qos = F@_6,
         is_retain = F@_7,
         payload = F@_8,
-        matched_acl = F@_9
+        matched_acl = F@_9,
+        persisted = F@_10
     }.
 
 'd_field_eventssidecar.v1.OnDeliveryComplete_timestamp'(
@@ -767,6 +1082,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_timestamp'(
@@ -783,6 +1099,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_timestamp'(
@@ -799,6 +1116,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -823,6 +1141,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     ).
 
@@ -840,6 +1159,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_username'(
@@ -856,6 +1176,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_username'(
@@ -872,6 +1193,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -881,7 +1203,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        RestF, 0, 0, F, F@_1, NewFValue, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, NewFValue, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliveryComplete_client_id'(
@@ -898,6 +1220,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_client_id'(
@@ -914,6 +1237,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_client_id'(
@@ -930,6 +1254,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -939,7 +1264,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        RestF, 0, 0, F, F@_1, F@_2, NewFValue, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, NewFValue, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliveryComplete_mountpoint'(
@@ -956,6 +1281,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_mountpoint'(
@@ -972,6 +1298,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_mountpoint'(
@@ -988,6 +1315,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -997,7 +1325,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, NewFValue, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, NewFValue, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliveryComplete_topic'(
@@ -1014,6 +1342,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_topic'(
@@ -1030,6 +1359,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_topic'(
@@ -1046,6 +1376,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -1055,7 +1386,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, NewFValue, F@_6, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, NewFValue, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliveryComplete_qos'(
@@ -1072,6 +1403,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_qos'(
@@ -1088,6 +1420,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_qos'(
@@ -1104,6 +1437,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = {
@@ -1114,7 +1448,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         Rest
     },
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, NewFValue, F@_7, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, NewFValue, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliveryComplete_is_retain'(
@@ -1131,6 +1465,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_is_retain'(
@@ -1147,6 +1482,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_is_retain'(
@@ -1163,11 +1499,12 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     _,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = {id(X bsl N + Acc =/= 0, TrUserData), Rest},
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, NewFValue, F@_8, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, NewFValue, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliveryComplete_payload'(
@@ -1184,6 +1521,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_payload'(
@@ -1200,6 +1538,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_payload'(
@@ -1216,6 +1555,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     _,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -1225,7 +1565,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         {id(Bytes2, TrUserData), Rest2}
     end,
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, NewFValue, F@_9, TrUserData
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, NewFValue, F@_9, F@_10, TrUserData
     ).
 
 'd_field_eventssidecar.v1.OnDeliveryComplete_matched_acl'(
@@ -1242,6 +1582,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'd_field_eventssidecar.v1.OnDeliveryComplete_matched_acl'(
@@ -1258,6 +1599,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'd_field_eventssidecar.v1.OnDeliveryComplete_matched_acl'(
@@ -1274,6 +1616,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     Prev,
+    F@_10,
     TrUserData
 ) ->
     {NewFValue, RestF} = begin
@@ -1298,7 +1641,64 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
             Prev == undefined -> NewFValue;
             true -> 'merge_msg_eventssidecar.v1.MatchedACL'(Prev, NewFValue, TrUserData)
         end,
+        F@_10,
         TrUserData
+    ).
+
+'d_field_eventssidecar.v1.OnDeliveryComplete_persisted'(
+    <<1:1, X:7, Rest/binary>>,
+    N,
+    Acc,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    F@_10,
+    TrUserData
+) when N < 57 ->
+    'd_field_eventssidecar.v1.OnDeliveryComplete_persisted'(
+        Rest,
+        N + 7,
+        X bsl N + Acc,
+        F,
+        F@_1,
+        F@_2,
+        F@_3,
+        F@_4,
+        F@_5,
+        F@_6,
+        F@_7,
+        F@_8,
+        F@_9,
+        F@_10,
+        TrUserData
+    );
+'d_field_eventssidecar.v1.OnDeliveryComplete_persisted'(
+    <<0:1, X:7, Rest/binary>>,
+    N,
+    Acc,
+    F,
+    F@_1,
+    F@_2,
+    F@_3,
+    F@_4,
+    F@_5,
+    F@_6,
+    F@_7,
+    F@_8,
+    F@_9,
+    _,
+    TrUserData
+) ->
+    {NewFValue, RestF} = {id(X bsl N + Acc =/= 0, TrUserData), Rest},
+    'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
+        RestF, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, NewFValue, TrUserData
     ).
 
 'skip_varint_eventssidecar.v1.OnDeliveryComplete'(
@@ -1315,10 +1715,11 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     'skip_varint_eventssidecar.v1.OnDeliveryComplete'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     );
 'skip_varint_eventssidecar.v1.OnDeliveryComplete'(
     <<0:1, _:7, Rest/binary>>,
@@ -1334,10 +1735,11 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'skip_length_delimited_eventssidecar.v1.OnDeliveryComplete'(
@@ -1354,6 +1756,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) when N < 57 ->
     'skip_length_delimited_eventssidecar.v1.OnDeliveryComplete'(
@@ -1370,6 +1773,7 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
         F@_7,
         F@_8,
         F@_9,
+        F@_10,
         TrUserData
     );
 'skip_length_delimited_eventssidecar.v1.OnDeliveryComplete'(
@@ -1386,20 +1790,21 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     Length = X bsl N + Acc,
     <<_:Length/binary, Rest2/binary>> = Rest,
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        Rest2, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest2, 0, 0, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'skip_group_eventssidecar.v1.OnDeliveryComplete'(
-    Bin, _, Z2, FNum, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+    Bin, _, Z2, FNum, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
 ) ->
     {_, Rest} = read_group(Bin, FNum),
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        Rest, 0, Z2, FNum, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, 0, Z2, FNum, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'skip_32_eventssidecar.v1.OnDeliveryComplete'(
@@ -1416,10 +1821,11 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'skip_64_eventssidecar.v1.OnDeliveryComplete'(
@@ -1436,10 +1842,11 @@ decode_msg_2_doit('eventssidecar.v1.MatchedACL', Bin, TrUserData) ->
     F@_7,
     F@_8,
     F@_9,
+    F@_10,
     TrUserData
 ) ->
     'dfp_read_field_def_eventssidecar.v1.OnDeliveryComplete'(
-        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, TrUserData
+        Rest, Z1, Z2, F, F@_1, F@_2, F@_3, F@_4, F@_5, F@_6, F@_7, F@_8, F@_9, F@_10, TrUserData
     ).
 
 'decode_msg_google.protobuf.Timestamp'(Bin, TrUserData) ->
@@ -1799,7 +2206,8 @@ merge_msgs(Prev, New, MsgName, Opts) ->
         qos = PFqos,
         is_retain = PFis_retain,
         payload = PFpayload,
-        matched_acl = PFmatched_acl
+        matched_acl = PFmatched_acl,
+        persisted = PFpersisted
     },
     #'eventssidecar.v1.OnDeliveryComplete'{
         timestamp = NFtimestamp,
@@ -1810,7 +2218,8 @@ merge_msgs(Prev, New, MsgName, Opts) ->
         qos = NFqos,
         is_retain = NFis_retain,
         payload = NFpayload,
-        matched_acl = NFmatched_acl
+        matched_acl = NFmatched_acl,
+        persisted = NFpersisted
     },
     TrUserData
 ) ->
@@ -1869,6 +2278,11 @@ merge_msgs(Prev, New, MsgName, Opts) ->
                     NFmatched_acl;
                 NFmatched_acl == undefined ->
                     PFmatched_acl
+            end,
+        persisted =
+            if
+                NFpersisted =:= undefined -> PFpersisted;
+                true -> NFpersisted
             end
     }.
 
@@ -1942,7 +2356,8 @@ verify_msg(Msg, MsgName, Opts) ->
         qos = F6,
         is_retain = F7,
         payload = F8,
-        matched_acl = F9
+        matched_acl = F9,
+        persisted = F10
     },
     Path,
     TrUserData
@@ -1982,6 +2397,10 @@ verify_msg(Msg, MsgName, Opts) ->
     if
         F9 == undefined -> ok;
         true -> 'v_submsg_eventssidecar.v1.MatchedACL'(F9, [matched_acl | Path], TrUserData)
+    end,
+    if
+        F10 == undefined -> ok;
+        true -> v_type_bool(F10, [persisted | Path], TrUserData)
     end,
     ok;
 'v_msg_eventssidecar.v1.OnDeliveryComplete'(X, Path, _TrUserData) ->
@@ -2159,6 +2578,14 @@ get_msg_defs() ->
                 type = {msg, 'eventssidecar.v1.MatchedACL'},
                 occurrence = optional,
                 opts = []
+            },
+            #field{
+                name = persisted,
+                fnum = 10,
+                rnum = 11,
+                type = bool,
+                occurrence = optional,
+                opts = []
             }
         ]},
         {{msg, 'google.protobuf.Timestamp'}, [
@@ -2234,6 +2661,9 @@ find_msg_def('eventssidecar.v1.OnDeliveryComplete') ->
             type = {msg, 'eventssidecar.v1.MatchedACL'},
             occurrence = optional,
             opts = []
+        },
+        #field{
+            name = persisted, fnum = 10, rnum = 11, type = bool, occurrence = optional, opts = []
         }
     ];
 find_msg_def('google.protobuf.Timestamp') ->

--- a/apps/vmq_webhooks/src/vmq_webhooks.app.src
+++ b/apps/vmq_webhooks/src/vmq_webhooks.app.src
@@ -27,7 +27,7 @@
             {vmq_webhooks_plugin, on_publish, 7, []},
             {vmq_webhooks_plugin, on_subscribe, 3, []},
             {vmq_webhooks_plugin, on_unsubscribe, 3, []},
-            {vmq_webhooks_plugin, on_deliver, 7, []},
+            {vmq_webhooks_plugin, on_deliver, 8, []},
 
             {vmq_webhooks_plugin, auth_on_register_m5, 6, []},
             {vmq_webhooks_plugin, auth_on_publish_m5, 7, []},
@@ -43,7 +43,7 @@
             {vmq_webhooks_plugin, on_client_wakeup, 1, []},
             {vmq_webhooks_plugin, on_client_offline, 2, []},
             {vmq_webhooks_plugin, on_session_expired, 1, []},
-            {vmq_webhooks_plugin, on_delivery_complete, 7, []},
+            {vmq_webhooks_plugin, on_delivery_complete, 8, []},
             {vmq_webhooks_plugin, on_client_gone, 2, []}
         ]}
     ]},

--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -49,13 +49,13 @@
     on_publish/7,
     on_subscribe/3,
     on_unsubscribe/3,
-    on_deliver/7,
+    on_deliver/8,
     on_offline_message/5,
     on_client_wakeup/1,
     on_client_offline/2,
     on_client_gone/2,
     on_session_expired/1,
-    on_delivery_complete/7,
+    on_delivery_complete/8,
 
     auth_on_register_m5/6,
     auth_on_publish_m5/7,
@@ -487,9 +487,9 @@ on_unsubscribe_m5(UserName, SubscriberId, Topics, Props) ->
         {properties, Props}
     ]).
 
--spec on_deliver(username(), subscriber_id(), qos(), topic(), payload(), flag(), _) ->
+-spec on_deliver(username(), subscriber_id(), qos(), topic(), payload(), flag(), _, _) ->
     'next' | 'ok' | {'ok', payload() | [on_deliver_hook:msg_modifier()]}.
-on_deliver(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _) ->
+on_deliver(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _, _) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     all_till_ok(on_deliver, [
         {username, nullify(UserName)},
@@ -501,9 +501,9 @@ on_deliver(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _) ->
         {retain, IsRetain}
     ]).
 
--spec on_delivery_complete(username(), subscriber_id(), qos(), topic(), payload(), flag(), _) ->
+-spec on_delivery_complete(username(), subscriber_id(), qos(), topic(), payload(), flag(), _, _) ->
     'next'.
-on_delivery_complete(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _) ->
+on_delivery_complete(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, _, _) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     all(on_delivery_complete, [
         {username, nullify(UserName)},

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -244,14 +244,14 @@ on_deliver_test(_) ->
     register_hook(on_deliver, ?ENDPOINT),
     Self = pid_to_bin(self()),
     ok = vmq_plugin:all_till_ok(on_deliver,
-                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #matched_acl{name = ?LABEL, pattern = ?PATTERN}]),
+                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #matched_acl{name = ?LABEL, pattern = ?PATTERN}, false]),
     ok = exp_response(on_deliver_ok),
     deregister_hook(on_deliver, ?ENDPOINT).
 
 on_delivery_complete_test(_) ->
   register_hook(on_delivery_complete, ?ENDPOINT),
   Self = pid_to_bin(self()),
-  [next] = vmq_plugin:all(on_delivery_complete,[Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #matched_acl{name = ?LABEL, pattern = ?PATTERN}]),
+  [next] = vmq_plugin:all(on_delivery_complete,[Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #matched_acl{name = ?LABEL, pattern = ?PATTERN}, false]),
   ok = exp_response(on_delivery_complete_ok),
   deregister_hook(on_delivery_complete, ?ENDPOINT).
 

--- a/rebar.config
+++ b/rebar.config
@@ -43,9 +43,7 @@
     {stdout_formatter, "0.2.3"},
     %% use specific cuttlefish commit until either 2.2.1 or 2.3.0 is relased.
     {cuttlefish, {git, "https://github.com/Kyorai/cuttlefish.git", {tag, "v2.3.0"}}},
-    {vernemq_dev,
-        {git, "https://github.com/VivekPipaliya23/vernemq_dev.git",
-            {branch, "feat/add-persisted-flag-for-offline-message"}}},
+    {vernemq_dev, {git, "https://github.com/gojekfarm/vernemq_dev.git", {branch, "master"}}},
     {syslog, "1.1.0"},
     {lager_syslog, {git, "https://github.com/basho/lager_syslog.git", {branch, "develop-3.0"}}},
     %% remove once clique hex package 3.0.2 is released

--- a/rebar.config
+++ b/rebar.config
@@ -43,7 +43,9 @@
     {stdout_formatter, "0.2.3"},
     %% use specific cuttlefish commit until either 2.2.1 or 2.3.0 is relased.
     {cuttlefish, {git, "https://github.com/Kyorai/cuttlefish.git", {tag, "v2.3.0"}}},
-    {vernemq_dev, {git, "https://github.com/gojekfarm/vernemq_dev.git", {branch, "master"}}},
+    {vernemq_dev,
+        {git, "https://github.com/VivekPipaliya23/vernemq_dev.git",
+            {branch, "feat/add-persisted-flag-for-offline-message"}}},
     {syslog, "1.1.0"},
     {lager_syslog, {git, "https://github.com/basho/lager_syslog.git", {branch, "develop-3.0"}}},
     %% remove once clique hex package 3.0.2 is released

--- a/rebar.lock
+++ b/rebar.lock
@@ -118,8 +118,8 @@
  {<<"syslog">>,{pkg,<<"syslog">>,<<"1.1.0">>},0},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.7.0">>},1},
  {<<"vernemq_dev">>,
-  {git,"https://github.com/VivekPipaliya23/vernemq_dev.git",
-       {ref,"6dc7c82fa1591e98ae044900e07d6f6d527253f3"}},
+  {git,"https://github.com/gojekfarm/vernemq_dev.git",
+       {ref,"4013b6235ac0c1a3a32193ba3c46eebdde0c2fa2"}},
   0}]}.
 [
 {pkg_hash,[

--- a/rebar.lock
+++ b/rebar.lock
@@ -118,8 +118,8 @@
  {<<"syslog">>,{pkg,<<"syslog">>,<<"1.1.0">>},0},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.7.0">>},1},
  {<<"vernemq_dev">>,
-  {git,"https://github.com/gojekfarm/vernemq_dev.git",
-       {ref,"fdbce09179bf60de67326f8fb66b3162bfb34fc8"}},
+  {git,"https://github.com/VivekPipaliya23/vernemq_dev.git",
+       {ref,"6dc7c82fa1591e98ae044900e07d6f6d527253f3"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
## Proposed Changes
This PR will add a flag called `persisted` to events `on_deliver` and `on_delivery_complete` to help identify whether the message is coming from offline store or not. Propagate this flag to sidecar events to web-hook plugin.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
