### PR TITLE
fix: extract version fn for empty new lines

### DIFF
--- a/apps/vmq_commons/src/vmq_util.erl
+++ b/apps/vmq_commons/src/vmq_util.erl
@@ -43,10 +43,18 @@ set_interval(Interval, Pid) ->
 extract_version(File) ->
     case file:read_file(File) of
         {ok, BinaryData} when byte_size(BinaryData) > 0 ->
-            Line = hd(string:tokens(binary_to_list(BinaryData), "\n")),
-            case re:run(Line, "#\\s*(v\\d+\\.\\d+\\.\\d+)", [{capture, [1], list}]) of
-                {match, [Version]} -> Version;
-                nomatch -> nomatch
+            Lines = string:tokens(binary_to_list(BinaryData), "\n"),
+            case Lines of
+                % If Lines is empty, return nomatch
+                [] ->
+                    nomatch;
+                [FirstLine | _Rest] ->
+                    case re:run(FirstLine, "#\\s*(v\\d+\\.\\d+\\.\\d+)", [{capture, [1], list}]) of
+                        {match, [Version]} ->
+                            Version;
+                        nomatch ->
+                            nomatch
+                    end
             end;
         {ok, _} ->
             nomatch;

--- a/apps/vmq_commons/src/vmq_util.erl
+++ b/apps/vmq_commons/src/vmq_util.erl
@@ -61,3 +61,41 @@ extract_version(File) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-define(setup(F), {setup, fun setup/0, fun teardown/1, F}).
+
+extract_version_test_() ->
+    [
+        {"Extract config version", ?setup(fun extract_version_test/1)}
+    ].
+
+setup() ->
+    %% Create a test file with some content
+    {ok, File} = file:open("test_file.acl", [write]),
+    file:write(File, "# v1.2.3\nSome text\n"),
+    file:close(File),
+    {ok, NoVersionFile} = file:open("no_version_file.acl", [write]),
+    file:write(NoVersionFile, "Some text\nRandom text\n"),
+    file:close(NoVersionFile),
+    {ok, EmptyFile} = file:open("empty_test_file.acl", [write]),
+    file:close(EmptyFile),
+    {ok, NewLineFile} = file:open("new_line_test_file.acl", [write]),
+    file:write(NewLineFile, "\n"),
+    file:close(NewLineFile).
+
+teardown(_) ->
+    file:delete("test_file.acl"),
+    file:delete("no_version_file.acl"),
+    file:delete("empty_test_file.acl"),
+    file:delete("new_line_test_file.acl").
+
+extract_version_test(_) ->
+    [
+        ?_assertEqual("v1.2.3", extract_version("test_file.acl")),
+        ?_assertEqual(nomatch, extract_version("no_version_file.acl")),
+        ?_assertEqual(nomatch, extract_version("empty_test_file.acl")),
+        ?_assertEqual(nomatch, extract_version("new_line_test_file.acl"))
+    ].
+-endif.


### PR DESCRIPTION
## Proposed Changes
Currently, the extracting version from a file that contains empty new lines will cause the process to crash.
this PR will fix that issue.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging