### PR TITLE
fix: reaped subs session expiry causing queue teardown tsunami

### DIFF
--- a/apps/vmq_server/src/vmq_redis_reaper.erl
+++ b/apps/vmq_server/src/vmq_redis_reaper.erl
@@ -186,10 +186,13 @@ handle_info(
         )
     of
         {ok, ClientList} when is_list(ClientList) ->
+            Duration = vmq_config:get_env(persistent_client_expiration, 0),
             lists:foreach(
                 fun([MP, ClientId]) ->
                     SubscriberId = {binary_to_list(MP), ClientId},
-                    {ok, _QueuePresent, _QPid} = vmq_queue_sup_sup:start_queue(SubscriberId, false)
+                    {ok, _QueuePresent, QPid} = vmq_queue_sup_sup:start_queue(SubscriberId, false),
+                    ExpireAfter = Duration + rand:uniform(Duration + 1),
+                    vmq_queue:update_session_expiry(QPid, ExpireAfter)
                 end,
                 ClientList
             ),


### PR DESCRIPTION
## Proposed Changes

Add jitter to session expiration timeout in order to control tsunami spike in queue teardown of reaped subscribers on queue transfer.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
