### PR TITLE
fix: reloading old plugin modules

### DIFF
--- a/apps/vmq_plugin/src/vmq_plugin_mgr.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_mgr.erl
@@ -561,6 +561,7 @@ start_plugin(App) ->
                 _ ->
                     ok
             end,
+            load_app_modules(App),
             {ok, Mods} = application:get_key(App, modules),
             case lists:member(App, Mods) of
                 true ->
@@ -575,7 +576,6 @@ start_plugin(App) ->
                 false ->
                     {ok, _} = application:ensure_all_started(App)
             end,
-            load_app_modules(App),
             ok;
         _ ->
             ok


### PR DESCRIPTION
## Proposed Changes
Currently, while reloading the plugin by performing the disable and enable plugin commands, it loads the older plugin modules. This change will load the new modules before starting the plugin. 

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [ ] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

