### PR TITLE
fix: old module code purge on plugin disable

### DIFF
--- a/apps/vmq_plugin/src/vmq_plugin_mgr.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_mgr.erl
@@ -642,6 +642,8 @@ stop_plugin(App, State) ->
     end,
     NewState = disable_app_module_plugins(App, State),
     purge_app_modules(App),
+    delete_app_modules(App),
+    purge_app_modules(App),
     application:unload(App),
     NewState.
 
@@ -741,6 +743,11 @@ create_paths(Path) ->
         false ->
             []
     end.
+
+delete_app_modules(App) ->
+    {ok, Modules} = application:get_key(App, modules),
+    lager:debug("deleting modules: ~p", [Modules]),
+    [code:delete(M) || M <- Modules].
 
 purge_app_modules(App) ->
     {ok, Modules} = application:get_key(App, modules),


### PR DESCRIPTION
## Proposed Changes
Previously, when we reloaded the plugin at runtime using `vmq-admin`, the old plugin module was not properly removed. This caused issues when trying to enable the new plugin. 
The changes in this pull request (PR) will ensure that the old code is correctly deleted and Purged. When re-enabling, the system will always use the newer code from the specified path.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging