### PR TITLE
fix: unable to vernemq attach switch to no_dot_erlang

### DIFF
--- a/files/runner
+++ b/files/runner
@@ -293,7 +293,7 @@ case "$1" in
         echo "q() or init:stop() will terminate the $SCRIPT node."
         shift
         NODE_NAME=${NAME_ARG#* }
-        exec $ERTS_PATH/erl -name c_$$_$NODE_NAME -hidden -remsh $NODE_NAME -boot start_clean $COOKIE_ARG $NET_TICKTIME_ARG
+        exec $ERTS_PATH/erl -name c_$$_$NODE_NAME -hidden -remsh $NODE_NAME -boot no_dot_erlang $COOKIE_ARG $NET_TICKTIME_ARG
         ;;
 
     console)


### PR DESCRIPTION
## Proposed Changes
This will fix the issue of being unable to execute `vernemq attach`.

Error:

```
> vernemq attach                                                                                                       
Remote Shell: Use "Ctrl-G q" to quit.
q() or init:stop() will terminate the vernemq node.
{"init terminating in do_boot",{'cannot get bootfile','start_clean.boot'}}
init terminating in do_boot ({cannot get bootfile,start_clean.boot})

Crash dump is being written to: erl_crash.dump...done
```
Reference:
similar Issue: https://github.com/vernemq/vernemq/issues/1873
Fix: https://github.com/vernemq/vernemq/commit/db7039c55fa7b1f16a805c07276925a5767c067d

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
