### PR TITLE
fix: reap subscriber process expiring existing queues

### DIFF
--- a/apps/vmq_server/src/vmq_redis_reaper.erl
+++ b/apps/vmq_server/src/vmq_redis_reaper.erl
@@ -190,9 +190,14 @@ handle_info(
             lists:foreach(
                 fun([MP, ClientId]) ->
                     SubscriberId = {binary_to_list(MP), ClientId},
-                    {ok, _QueuePresent, QPid} = vmq_queue_sup_sup:start_queue(SubscriberId, false),
-                    ExpireAfter = Duration + rand:uniform(Duration + 1),
-                    vmq_queue:update_session_expiry(QPid, ExpireAfter)
+                    {ok, QueuePresent, QPid} = vmq_queue_sup_sup:start_queue(SubscriberId, false),
+                    case QueuePresent of
+                        true ->
+                            ok;
+                        false ->
+                            ExpireAfter = Duration + rand:uniform(Duration + 1),
+                            vmq_queue:update_session_expiry(QPid, ExpireAfter)
+                    end
                 end,
                 ClientList
             ),

--- a/apps/vmq_server/src/vmq_redis_reaper.erl
+++ b/apps/vmq_server/src/vmq_redis_reaper.erl
@@ -191,6 +191,7 @@ handle_info(
                 fun([MP, ClientId]) ->
                     SubscriberId = {binary_to_list(MP), ClientId},
                     {ok, QueuePresent, QPid} = vmq_queue_sup_sup:start_queue(SubscriberId, false),
+                    lager:error("Test: ClientId: ~p, QueuePresent: ~p", [ClientId, QueuePresent]),
                     case QueuePresent of
                         true ->
                             ok;

--- a/apps/vmq_server/src/vmq_redis_reaper.erl
+++ b/apps/vmq_server/src/vmq_redis_reaper.erl
@@ -191,7 +191,6 @@ handle_info(
                 fun([MP, ClientId]) ->
                     SubscriberId = {binary_to_list(MP), ClientId},
                     {ok, QueuePresent, QPid} = vmq_queue_sup_sup:start_queue(SubscriberId, false),
-                    lager:error("Test: ClientId: ~p, QueuePresent: ~p", [ClientId, QueuePresent]),
                     case QueuePresent of
                         true ->
                             ok;


### PR DESCRIPTION
## Proposed Changes
This PR addresses the issue where, if one instance of the broker cluster goes down, the other brokers attempt to reap the subscribers from the unavailable instance. During this time, any subscriber might automatically connect to another broker. Nevertheless, the reap subscriber process will still try to place the client in the offline queue and update its session for expiry. This change will prevent online clients from being marked for session expiry.

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
