### PR TITLE
feat: add register_auth error metric with reasons

### DIFF
--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.app.src
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.app.src
@@ -13,6 +13,7 @@
         {file, "priv/test.acl"},
         {interval, 10},
         {vmq_config_enabled, true},
+        {vmq_metrics_mfa, {vmq_enhanced_auth_metrics, metrics, []}},
         {vmq_plugin_hooks, [
             {vmq_enhanced_auth, change_config, 1, [internal]},
             {vmq_enhanced_auth, auth_on_publish, 6, []},

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.hrl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth.hrl
@@ -1,0 +1,4 @@
+-define(REGISTER_AUTH_ERROR, register_auth_error).
+-define(INVALID_SIGNATURE, invalid_signature).
+-define(USERNAME_RID_MISMATCH, username_rid_mismatch).
+-define(MISSING_RID, missing_rid).

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth_metrics.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth_metrics.erl
@@ -1,0 +1,265 @@
+%% Copyright Gojek
+
+-module(vmq_enhanced_auth_metrics).
+
+-behaviour(gen_server).
+
+%% API
+-export([
+    start_link/0,
+    metrics/0,
+    metrics/1,
+    incr/1,
+    incr/2
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-define(SERVER, ?MODULE).
+
+-include_lib("vmq_enhanced_auth/src/vmq_enhanced_auth.hrl").
+
+-record(state, {}).
+-record(metric_def, {
+    type :: atom(),
+    labels :: [metric_label()],
+    id :: metric_id(),
+    name :: atom(),
+    description :: undefined | binary()
+}).
+
+-type metric_def() :: #metric_def{}.
+-type metric_label() :: {atom(), string()}.
+-type metric_id() ::
+    atom()
+    | {atom(), non_neg_integer() | atom()}
+    | {atom(), atom(), atom()}
+    | [{atom(), [{atom(), any()}]}].
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec metrics() -> [{metric_def(), non_neg_integer()}].
+metrics() ->
+    metrics(#{aggregate => false}).
+
+-spec metrics(map()) -> [{metric_def(), non_neg_integer()}].
+metrics(Opts) ->
+    WantLabels = maps:get(labels, Opts, []),
+
+    MetricDefs = metrics_defs(),
+    MetricValues = metric_values(),
+
+    %% Create id->metric def map
+    IdDef = lists:foldl(
+        fun(#metric_def{id = Id} = MD, Acc) ->
+            maps:put(Id, MD, Acc)
+        end,
+        #{},
+        MetricDefs
+    ),
+
+    %% Merge metrics definitions with values and filter based on labels.
+    Metrics = lists:filtermap(
+        fun({Id, Val}) ->
+            case maps:find(Id, IdDef) of
+                {ok, #metric_def{type = Type, id = Id, name = Name, labels = GotLabels, description = Description}} ->
+                    Keep = has_label(WantLabels, GotLabels),
+                    case Keep of
+                        true ->
+                            {true, {Type, GotLabels, Id, Name, Description, Val}};
+                        _ ->
+                            false
+                    end;
+                error ->
+                    %% this could happen if metric definitions does
+                    %% not correspond to the ids returned with the
+                    %% metrics values.
+                    lager:warning("unknown metrics id: ~p", [Id]),
+                    false
+            end
+        end,
+        MetricValues
+    ),
+
+    case Opts of
+        #{aggregate := true} ->
+            aggregate_by_name(Metrics);
+        _ ->
+            Metrics
+    end.
+
+-spec incr(any()) -> 'ok'.
+incr(Entry) ->
+    incr_item(Entry, 1).
+
+-spec incr(any(), non_neg_integer()) -> 'ok'.
+incr(Entry, N) ->
+    incr_item(Entry, N).
+
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    AllEntries = [Id || #metric_def{id = Id} <- metrics_defs()],
+    NumEntries = length(AllEntries),
+    %% Sanity check where it is checked that there is a one-to-one
+    %% mapping between atomics indexes and metrics identifiers by 1)
+    %% checking that all metric identifiers have an atomics index and
+    %% 2) that there are as many indexes as there are metrics and 3)
+    %% that there are no index duplicates.
+    Idxs = lists:map(fun(Id) -> met2idx(Id) end, AllEntries),
+    NumEntries = length(lists:sort(Idxs)),
+    NumEntries = length(lists:usort(Idxs)),
+
+    %% only alloc a new atomics array if one doesn't already exist!
+    case catch persistent_term:get(?MODULE) of
+        {'EXIT', {badarg, _}} ->
+            %% allocate twice the number of entries to make it possible to add
+            %% new metrics during a hot code upgrade.
+            ARef = atomics:new(2 * NumEntries, [{signed, false}]),
+            persistent_term:put(?MODULE, ARef);
+        _ExistingRef ->
+            ok
+    end,
+    {ok, #state{}}.
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+
+%% don't do the update
+incr_item(_, 0) ->
+    ok;
+incr_item(Entry, Val) when Val > 0 ->
+    ARef =
+        case get(vmq_enhanced_auth_atomics_ref) of
+            undefined ->
+                Ref = persistent_term:get(?MODULE),
+                put(vmq_enhanced_auth_atomics_ref, Ref),
+                Ref;
+            Ref ->
+                Ref
+        end,
+    atomics:add(ARef, met2idx(Entry), Val).
+
+
+metric_values() -> 
+    lists:map(
+        fun(#metric_def{id = Id}) ->
+            try counter_val(Id) of
+                Value -> {Id, Value}
+            catch
+                _:_ -> {Id, 0}
+            end
+        end,
+        metrics_defs()
+    ).
+
+-spec metrics_defs() -> none().
+metrics_defs() ->
+    [
+        m(
+            counter,
+            [
+                {reason, ?INVALID_SIGNATURE}
+            ],
+            {?REGISTER_AUTH_ERROR, ?INVALID_SIGNATURE},
+            ?REGISTER_AUTH_ERROR,
+            <<"The number of times the auth_on_register hook returned error due to invalid_signature.">>
+        ),
+        m(
+            counter,
+            [
+                {reason, ?MISSING_RID}
+            ],
+            {?REGISTER_AUTH_ERROR, ?MISSING_RID},
+            ?REGISTER_AUTH_ERROR,
+            <<"The number of times the auth_on_register hook returned error due to missing_rid.">>
+        ),
+        m(
+            counter,
+            [
+                {reason, ?USERNAME_RID_MISMATCH}
+            ],
+            {?REGISTER_AUTH_ERROR, ?USERNAME_RID_MISMATCH},
+            ?REGISTER_AUTH_ERROR,
+            <<"The number of times the auth_on_register hook returned error due to username_rid_mismatch.">>
+        )
+    ].
+
+m(Type, Labels, UniqueId, Name, Description) ->
+    #metric_def{
+        type = Type,
+        labels = Labels,
+        id = UniqueId,
+        name = Name,
+        description = Description
+    }.
+
+counter_val(Entry) ->
+    ARef = persistent_term:get(?MODULE),
+    atomics:get(ARef, met2idx(Entry)).
+
+has_label([], _) ->
+    true;
+has_label(WantLabels, GotLabels) when is_list(WantLabels), is_list(GotLabels) ->
+    lists:all(
+        fun(T1) ->
+            lists:member(T1, GotLabels)
+        end,
+        WantLabels
+    ).
+
+aggregate_by_name(Metrics) ->
+    AggrMetrics = lists:foldl(
+        fun({#metric_def{name = Name} = D1, V1}, Acc) ->
+            case maps:find(Name, Acc) of
+                {ok, {_D2, V2}} ->
+                    Acc#{Name => {D1#metric_def{labels = []}, V1 + V2}};
+                error ->
+                    %% Remove labels when aggregating.
+                    Acc#{Name => {D1#metric_def{labels = []}, V1}}
+            end
+        end,
+        #{},
+        Metrics
+    ),
+    maps:values(AggrMetrics).
+
+
+met2idx({?REGISTER_AUTH_ERROR, ?INVALID_SIGNATURE}) -> 1;
+met2idx({?REGISTER_AUTH_ERROR, ?USERNAME_RID_MISMATCH}) -> 2;
+met2idx({?REGISTER_AUTH_ERROR, ?MISSING_RID}) -> 3.

--- a/apps/vmq_enhanced_auth/src/vmq_enhanced_auth_sup.erl
+++ b/apps/vmq_enhanced_auth/src/vmq_enhanced_auth_sup.erl
@@ -37,4 +37,4 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-    {ok, {{one_for_one, 5, 10}, [?CHILD(vmq_enhanced_auth_reloader, worker)]}}.
+    {ok, {{one_for_one, 5, 10}, [?CHILD(vmq_enhanced_auth_reloader, worker), ?CHILD(vmq_enhanced_auth_metrics, worker)]}}.


### PR DESCRIPTION
## Proposed Changes

This adds instrumentation in vmq_enhanced_auth plugin for granular level observability on auth_on_register error response.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
