### PR TITLE
feat: introduce new metric active_mqtt_connections

### DIFF
--- a/apps/vmq_server/src/vmq_health_http.erl
+++ b/apps/vmq_server/src/vmq_health_http.erl
@@ -71,7 +71,7 @@ cluster_status() ->
 -spec listeners_status() -> ok | {error, Reason :: string()}.
 listeners_status() ->
     NotRunningListeners = lists:filtermap(
-        fun({Type, _, _, Status, _, _, _}) ->
+        fun({Type, _, _, Status, _, _, _, _, _}) ->
             case Status of
                 running ->
                     false;

--- a/apps/vmq_server/src/vmq_listener_cli.erl
+++ b/apps/vmq_server/src/vmq_listener_cli.erl
@@ -312,7 +312,7 @@ vmq_listener_show_cmd() ->
         fun(_, [], []) ->
             Table =
                 lists:foldl(
-                    fun({Type, Ip, Port, Status, MP, MaxConns, PP}, Acc) ->
+                    fun({Type, Ip, Port, Status, MP, MaxConns, PP, ActiveConns, AllConns}, Acc) ->
                         [
                             [
                                 {type, Type},
@@ -321,7 +321,9 @@ vmq_listener_show_cmd() ->
                                 {port, Port},
                                 {mountpoint, MP},
                                 {max_conns, MaxConns},
-                                {proxy_protocol, PP}
+                                {proxy_protocol, PP},
+                                {active_conns, ActiveConns},
+                                {all_conns, AllConns}
                             ]
                             | Acc
                         ]

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -2153,13 +2153,19 @@ fetch_external_metric(Mod, Fun, Default) ->
 misc_statistics() ->
     {NrOfSubs, SMemory} = fetch_external_metric(vmq_reg_trie, stats, {0, 0}),
     {NrOfRetain, RMemory} = fetch_external_metric(vmq_retain_srv, stats, {0, 0}),
+    {NrOfMQTTConnections, NrOfMQTTWSConnections} = fetch_external_metric(
+        vmq_ranch_sup, active_mqtt_connections, {0, 0}
+    ),
     [
         {router_subscriptions, NrOfSubs},
         {router_memory, SMemory},
         {retain_messages, NrOfRetain},
         {retain_memory, RMemory},
         {queue_processes, fetch_external_metric(vmq_queue_sup_sup, nr_of_queues, 0)},
-        {offline_messages, fetch_external_metric(vmq_message_store, nr_of_offline_messages, 0)}
+        {offline_messages, fetch_external_metric(vmq_message_store, nr_of_offline_messages, 0)},
+        {active_mqttws_connections, NrOfMQTTWSConnections},
+        {active_mqtt_connections, NrOfMQTTConnections},
+        {total_active_connections, NrOfMQTTWSConnections + NrOfMQTTConnections}
     ].
 
 -spec misc_stats_def() -> [metric_def()].
@@ -2194,7 +2200,28 @@ misc_stats_def() ->
             <<"The number of bytes used for storing retained messages.">>
         ),
         m(gauge, [], queue_processes, queue_processes, <<"The number of MQTT queue processes.">>),
-        m(gauge, [], offline_messages, offline_messages, <<"The number of offline messages">>)
+        m(gauge, [], offline_messages, offline_messages, <<"The number of offline messages">>),
+        m(
+            gauge,
+            [],
+            active_mqtt_connections,
+            active_mqtt_connections,
+            <<"The number of active MQTT(S) connections.">>
+        ),
+        m(
+            gauge,
+            [],
+            active_mqttws_connections,
+            active_mqttws_connections,
+            <<"The number of active MQTT WS(S) connections.">>
+        ),
+        m(
+            gauge,
+            [],
+            total_active_connections,
+            total_active_connections,
+            <<"The total number of active MQTT and MQTTWS connections.">>
+        )
     ].
 
 -spec system_statistics() -> [{metric_id(), any()}].

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -135,51 +135,38 @@ start_listener(Type, Addr, Port, {TransportOpts, Opts}) ->
     end.
 
 listeners() ->
-    lists:foldl(
-        fun
-            ({ranch_server, _, _, _}, Acc) ->
-                Acc;
-            ({{ranch_listener_sup, {Ip, Port}}, Status, supervisor, _}, Acc) ->
-                {ok, {Type, Opts}} = get_listener_config(Ip, Port),
-                MountPoint = proplists:get_value(mountpoint, Opts, ""),
-                MaxConnections = proplists:get_value(
-                    max_connections,
-                    Opts,
-                    vmq_config:get_env(max_connections)
-                ),
-                Status1 =
-                    case Status of
-                        restarting ->
-                            restarting;
-                        undefined ->
-                            stopped;
-                        Pid when is_pid(Pid) ->
-                            case
-                                lists:keyfind(
-                                    ranch_acceptors_sup, 1, supervisor:which_children(Pid)
-                                )
-                            of
-                                false ->
-                                    not_found;
-                                {_, restarting, supervisor, _} ->
-                                    restarting;
-                                {_, undefined, supervisor, _} ->
-                                    stopped;
-                                {_, AcceptorPid, supervisor, _} when is_pid(AcceptorPid) ->
-                                    running
-                            end
-                    end,
-                StrIp = inet:ntoa(Ip),
-                StrPort = integer_to_list(Port),
-                ProxyProtocol = proplists:get_value(
-                    proxy_protocol,
-                    Opts,
-                    false
-                ),
-                [{Type, StrIp, StrPort, Status1, MountPoint, MaxConnections, ProxyProtocol} | Acc]
+    maps:fold(
+        fun({Ip, Port}, ConfigMap, Acc) ->
+            {ok, {Type, Opts}} = get_listener_config(Ip, Port),
+            MountPoint = proplists:get_value(mountpoint, Opts, ""),
+            MaxConnections = proplists:get_value(
+                max_connections,
+                Opts,
+                vmq_config:get_env(max_connections)
+            ),
+            ActiveConnections = maps:get(active_connections, ConfigMap),
+            % the highest number of connections seen
+            AllConnections = maps:get(all_connections, ConfigMap),
+            Status = maps:get(status, ConfigMap),
+            StrIp =
+                case Ip of
+                    {local, FS} -> {local, FS};
+                    _ -> inet:ntoa(Ip)
+                end,
+            StrPort = integer_to_list(Port),
+            ProxyProtocol = proplists:get_value(
+                proxy_protocol,
+                Opts,
+                false
+            ),
+            [
+                {Type, StrIp, StrPort, Status, MountPoint, MaxConnections, ProxyProtocol,
+                    ActiveConnections, AllConnections}
+                | Acc
+            ]
         end,
         [],
-        supervisor:which_children(ranch_sup)
+        ranch:info()
     ).
 
 get_listener_config(Addr, Port) ->

--- a/apps/vmq_server/src/vmq_status_http.erl
+++ b/apps/vmq_server/src/vmq_status_http.erl
@@ -69,12 +69,12 @@ cluster_status() ->
 
 node_status() ->
     % Total Connections
-    SocketOpen = counter_val(?METRIC_SOCKET_OPEN),
-    SocketClose = counter_val(?METRIC_SOCKET_CLOSE),
-    TotalConnections = SocketOpen - SocketClose,
+    TotalActiveMqttConnections = lists:sum(
+        tuple_to_list(vmq_ranch_sup:active_mqtt_connections())
+    ),
     % Total Online Queues
     TotalQueues = vmq_queue_sup_sup:nr_of_queues(),
-    TotalOfflineQueues = TotalQueues - TotalConnections,
+    TotalOfflineQueues = TotalQueues - TotalActiveMqttConnections,
     TotalPublishIn =
         counter_val(?MQTT4_PUBLISH_RECEIVED) +
             counter_val(?MQTT5_PUBLISH_RECEIVED),
@@ -90,7 +90,7 @@ node_status() ->
     {NrOfSubs, _SMemory} = vmq_reg_trie:stats(),
     {NrOfRetain, _RMemory} = vmq_retain_srv:stats(),
     {ok, [
-        {<<"num_online">>, TotalConnections},
+        {<<"num_online">>, TotalActiveMqttConnections},
         {<<"num_offline">>, TotalOfflineQueues},
         {<<"msg_in">>, TotalPublishIn},
         {<<"msg_out">>, TotalPublishOut},
@@ -118,12 +118,17 @@ counter_val(C) ->
 
 listeners() ->
     lists:foldl(
-        fun({Type, Ip, Port, Status, MP, MaxConns, PP}, Acc) ->
+        fun({Type, Ip, Port, Status, MP, MaxConns, PP, _, _}, Acc) ->
+            Ip1 =
+                case Ip of
+                    {local, FS} -> list_to_binary(FS);
+                    Any -> list_to_binary(Any)
+                end,
             [
                 [
                     {type, Type},
                     {status, Status},
-                    {ip, list_to_binary(Ip)},
+                    {ip, Ip1},
                     {port, list_to_integer(Port)},
                     {mountpoint, MP},
                     {max_conns, MaxConns},


### PR DESCRIPTION
## Proposed Changes
Adds a new metric active_mqtt_connections that replaces the old logic of counting open and closed sockets. The metric is then used for the status page which should not show negative offline clients anymore.
https://github.com/vernemq/vernemq/pull/2076

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue https://github.com/vernemq/vernemq/issues/760)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CODE_OF_CONDUCT.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
