### PR TITLE
feat: Reject NULL bytes in MQTT CONNECT client_id

### DIFF
--- a/apps/vmq_commons/src/vmq_parser.erl
+++ b/apps/vmq_commons/src/vmq_parser.erl
@@ -463,6 +463,13 @@ utf8(IoList) when is_list(IoList) ->
 utf8(Bin) when is_binary(Bin) ->
     <<(byte_size(Bin)):16/big, Bin/binary>>.
 
+ensure_utf8(Bin) when is_binary(Bin) ->
+    case {unicode:characters_to_binary(Bin, utf8, utf8), binary:match(Bin, <<0>>)} of
+        {{error, _, _}, _} -> {error, invalid_utf8_string};
+        {_, {_, _}} -> {error, invalid_utf8_string};
+        {X, nomatch} -> {ok, X}
+    end.
+
 ensure_binary(L) when is_list(L) -> list_to_binary(L);
 ensure_binary(B) when is_binary(B) -> B;
 ensure_binary(undefined) -> undefined;

--- a/apps/vmq_commons/src/vmq_parser_mqtt5.erl
+++ b/apps/vmq_commons/src/vmq_parser_mqtt5.erl
@@ -696,6 +696,13 @@ utf8(IoList) when is_list(IoList) ->
 utf8(Bin) when is_binary(Bin) ->
     <<(byte_size(Bin)):16/big, Bin/binary>>.
 
+ensure_utf8(Bin) when is_binary(Bin) ->
+    case {unicode:characters_to_binary(Bin, utf8, utf8), binary:match(Bin, <<0>>)} of
+        {{error, _, _}, _} -> {error, invalid_utf8_string};
+        {_, {_, _}} -> {error, invalid_utf8_string};
+        {X, nomatch} -> {ok, X}
+    end.
+
 binary(X) ->
     %% We encode MQTT binaries the same as utf8, but use this function
     %% to document the difference.

--- a/apps/vmq_commons/test/vmq_parser_SUITE.erl
+++ b/apps/vmq_commons/test/vmq_parser_SUITE.erl
@@ -28,7 +28,8 @@ all() ->
      enough_data_max_not_exceeded,
      not_enough_data_max_exceeded,
      not_enough_data_max_not_exceeded,
-     parse_unparse_tests     
+     parse_unparse_tests,
+     no_null_char_in_client
     ].
 
 %%--------------------------------------------------------------------
@@ -64,6 +65,10 @@ not_enough_data_max_not_exceeded(_Config) ->
     PartialSize = byte_size(CompletePacket) - 1,
     <<IncompletePacket:PartialSize/binary, _LastByte/binary>> = CompletePacket,
     more  = vmq_parser:parse(IncompletePacket, byte_size(CompletePacket)).
+
+no_null_char_in_client(_Config) ->
+    C = vmq_parser:gen_connect(<<1,0>>, []),
+    {{error, invalid_utf8_string}, <<>>} = vmq_parser:parse(C).
 
 parse_unparse_tests(_Config) ->
     compare_frame("connect1", vmq_parser:gen_connect("test-client", [])),

--- a/apps/vmq_commons/test/vmq_parser_mqtt5_SUITE.erl
+++ b/apps/vmq_commons/test/vmq_parser_mqtt5_SUITE.erl
@@ -38,7 +38,8 @@ all() ->
      parse_unparse_pingreq_test,
      parse_unparse_pingresp_test,
      parse_unparse_disconnect_test,
-     parse_unparse_auth_test].
+     parse_unparse_auth_test,
+     no_null_char_in_client].
 
 parse_unparse_tests(_Config) ->
     Properties = #{p_session_expiry_interval => 12341234},
@@ -259,6 +260,10 @@ parse_unparse_properties_test(_Config) ->
 
     parse_unparse_property(#{p_shared_subs_available => true}),
     parse_unparse_property(#{p_shared_subs_available => false}).
+
+no_null_char_in_client(_Config) ->
+    C = vmq_parser_mqtt5:gen_connect(<<1,0>>, []),
+    {{error, invalid_utf8_string}, <<>>} = vmq_parser_mqtt5:parse(C).
 
 parse_unparse_property(Property) ->
     Encoded = enc_property_(Property),


### PR DESCRIPTION
## Proposed Changes

This PR is added from VerneMQ vanilla

Changes:
- Add ensure_utf8/1 with invalid UTF-8 and NULL byte check in vmq_parser.erl and vmq_parser_mqtt5.erl
- Wire ensure_utf8 on CONNECT client_id in both parsers
- Add no_null_char_in_client tests in both CT suites

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)