### PR TITLE
fix: send SUBACK on all subscribe error paths

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -656,11 +656,17 @@ connected(#mqtt5_subscribe{message_id = MessageId, topics = Topics, properties =
             Frame = #mqtt5_suback{message_id = MessageId, reason_codes = QoSs, properties = #{}},
             _ = vmq_metrics:incr(?MQTT5_SUBSCRIBE_AUTH_ERROR),
             {State, [serialise_frame(Frame)]};
-        {error, _Reason} ->
-            %% cant subscribe due to overload or netsplit,
-            %% Subscribe uses QoS 1 so the client will retry
+        {error, Reason} ->
+            %% cant subscribe due to overload or netsplit, or no plugin available
+            %% we still want to send out a generic not_authorized SUBACK
+            QoSs = [rcn2rc(?NOT_AUTHORIZED) || _ <- Topics],
+            Frame = #mqtt5_suback{message_id = MessageId, reason_codes = QoSs, properties = #{}},
+            lager:error(
+                "can't authorize SUBSCRIBE from v5 client ~p from ~s due to ~p",
+                [SubscriberId, peertoa(State#state.peer), Reason]
+            ),
             _ = vmq_metrics:incr(?MQTT5_SUBSCRIBE_ERROR),
-            {State, []}
+            {State, [serialise_frame(Frame)]}
     end;
 connected(#mqtt5_unsubscribe{message_id = MessageId, topics = Topics, properties = Props0}, State) ->
     #state{

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -510,15 +510,24 @@ connected(
             {State, [Frame]};
         {error, not_allowed} ->
             %% allow the parser to add the 0x80 Failure return code
+            lager:error(
+                "can't authorize SUBSCRIBE from v3 client ~p from ~s due to not_authorized",
+                [SubscriberId, peertoa(State#state.peer)]
+            ),
             QoSs = [not_allowed || _ <- Topics],
             Frame = #mqtt_suback{message_id = MessageId, qos_table = QoSs},
             _ = vmq_metrics:incr_mqtt_error_auth_subscribe(),
             {State, [Frame]};
-        {error, _Reason} ->
+        {error, Reason} ->
             %% cant subscribe due to overload or netsplit,
-            %% Subscribe uses QoS 1 so the client will retry
+            lager:error(
+                "can't authorize SUBSCRIBE from v3 client ~p from ~s due to ~p",
+                [SubscriberId, peertoa(State#state.peer), Reason]
+            ),
+            QoSs = [not_allowed || _ <- Topics],
+            Frame = #mqtt_suback{message_id = MessageId, qos_table = QoSs},
             _ = vmq_metrics:incr_mqtt_error_subscribe(),
-            {State, []}
+            {State, [Frame]}
     end;
 connected(#mqtt_unsubscribe{message_id = MessageId, topics = Topics}, State) ->
     #state{


### PR DESCRIPTION
## Proposed Changes
This change is from vanilla VerneMQ

PR: https://github.com/vernemq/vernemq/pull/2456
- v5 FSM: generic subscribe errors now return SUBACK with NOT_AUTHORIZED reason codes instead of no reply
- v3 FSM: generic subscribe errors now return SUBACK with not_allowed; both error clauses log via lager:error

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)