### PR TITLE
fix: max_packet_size parser checks

### DIFF
--- a/apps/vmq_commons/src/vmq_parser.erl
+++ b/apps/vmq_commons/src/vmq_parser.erl
@@ -56,6 +56,8 @@ parse(Data) ->
     parse(Data, ?MAX_PACKET_SIZE).
 
 -spec parse(binary(), non_neg_integer()) -> {mqtt_frame(), binary()} | {error, atom()} | more.
+parse(Data, MaxSize) when MaxSize > ?MAX_PACKET_SIZE ->
+    parse(Data, ?MAX_PACKET_SIZE);
 parse(<<Fixed:1/binary, 0:1, DataSize:7, Data/binary>>, MaxSize) ->
     parse(DataSize, MaxSize, Fixed, Data);
 parse(<<Fixed:1/binary, 1:1, L1:7, 0:1, L2:7, Data/binary>>, MaxSize) ->
@@ -69,20 +71,19 @@ parse(<<_:8/binary, _/binary>>, _) ->
 parse(_, _) ->
     more.
 
-parse(DataSize, 0, Fixed, Data) when byte_size(Data) >= DataSize ->
-    %% no max size limit
-    <<Var:DataSize/binary, Rest/binary>> = Data,
-    {variable(Fixed, Var), Rest};
-parse(DataSize, 0, _Fixed, Data) when byte_size(Data) < DataSize ->
-    more;
+parse(DataSize, 0, Fixed, Data) ->
+    parse(DataSize, ?MAX_PACKET_SIZE, Fixed, Data);
 parse(DataSize, MaxSize, Fixed, Data) when
     byte_size(Data) >= DataSize,
-    byte_size(Data) =< MaxSize
+    byte_size(Data) =< MaxSize,
+    MaxSize =< ?MAX_PACKET_SIZE
 ->
     <<Var:DataSize/binary, Rest/binary>> = Data,
     {variable(Fixed, Var), Rest};
-parse(DataSize, MaxSize, _, _) when
-    DataSize > MaxSize
+parse(DataSize, MaxSize, _, Data) when
+    DataSize > MaxSize;
+    MaxSize > ?MAX_PACKET_SIZE;
+    byte_size(Data) > ?MAX_PACKET_SIZE
 ->
     {error, packet_exceeds_max_size};
 parse(_, _, _, _) ->

--- a/apps/vmq_commons/src/vmq_parser_mqtt5.erl
+++ b/apps/vmq_commons/src/vmq_parser_mqtt5.erl
@@ -46,6 +46,8 @@ parse(Data) ->
 
 -spec parse(binary(), non_neg_integer()) ->
     {mqtt5_frame(), binary()} | {error, atom()} | {{error, atom()}, any()} | more.
+parse(Data, MaxSize) when MaxSize > ?MAX_PACKET_SIZE ->
+    parse(Data, ?MAX_PACKET_SIZE);
 parse(<<Fixed:1/binary, 0:1, DataSize:7, Data/binary>>, MaxSize) ->
     parse(DataSize, MaxSize, Fixed, Data);
 parse(<<Fixed:1/binary, 1:1, L1:7, 0:1, L2:7, Data/binary>>, MaxSize) ->
@@ -59,20 +61,19 @@ parse(<<_:8/binary, _/binary>>, _) ->
 parse(_, _) ->
     more.
 
-parse(DataSize, 0, Fixed, Data) when byte_size(Data) >= DataSize ->
-    %% no max size limit
-    <<Var:DataSize/binary, Rest/binary>> = Data,
-    {variable(Fixed, Var), Rest};
-parse(DataSize, 0, _Fixed, Data) when byte_size(Data) < DataSize ->
-    more;
+parse(DataSize, 0, Fixed, Data) ->
+    parse(DataSize, ?MAX_PACKET_SIZE, Fixed, Data);
 parse(DataSize, MaxSize, Fixed, Data) when
     byte_size(Data) >= DataSize,
-    byte_size(Data) =< MaxSize
+    byte_size(Data) =< MaxSize,
+    MaxSize =< ?MAX_PACKET_SIZE
 ->
     <<Var:DataSize/binary, Rest/binary>> = Data,
     {variable(Fixed, Var), Rest};
-parse(DataSize, MaxSize, _, _) when
-    DataSize > MaxSize
+parse(DataSize, MaxSize, _, Data) when
+    DataSize > MaxSize;
+    MaxSize > ?MAX_PACKET_SIZE;
+    byte_size(Data) > ?MAX_PACKET_SIZE
 ->
     {error, packet_exceeds_max_size};
 parse(_, _, _, _) ->


### PR DESCRIPTION
## Proposed Changes

This change is from vanilla VerneMQ
 
Changes: 
- Cap MaxSize at ?MAX_PACKET_SIZE in parse/2 entry
- Remove unlimited parse path when MaxSize=0 (redirect to ?MAX_PACKET_SIZE)
- Reject oversize buffers and invalid MaxSize early with packet_exceeds_max_size

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)