### PR TITLE
feat: monotonic keepalive timers

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -31,8 +31,6 @@
 -define(EXPIRY_INT_MAX, 16#FFFFFFFF).
 -define(MAX_PACKET_SIZE, 16#FFFFFFF).
 
--type timestamp() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}.
-
 -type topic_aliases_in() :: map().
 -type topic_aliases_out() :: map().
 
@@ -65,8 +63,7 @@
     proto_ver :: undefined | pos_integer(),
     queue_pid :: pid() | undefined,
 
-    last_time_active = os:timestamp() :: timestamp(),
-    last_trigger = os:timestamp() :: timestamp(),
+    last_time_active = erlang:monotonic_time(microsecond) :: integer(),
 
     %% Data used for enhanced authentication and
     %% re-authentication. TODOv5: move this to pdict?
@@ -120,7 +117,7 @@ init(
         proto_ver = ProtoVer
     } = ConnectFrame
 ) ->
-    rand:seed(exsplus, os:timestamp()),
+    rand:seed(exsplus),
     MountPoint = proplists:get_value(mountpoint, Opts, ""),
     SubscriberId = {string:strip(MountPoint, right, $/), undefined},
     AllowedProtocolVersions = proplists:get_value(
@@ -191,7 +188,7 @@ init(
         trace_fun = TraceFun,
         fc_receive_max_client = FcReceiveMaxClient,
         fc_receive_max_broker = FcReceiveMaxBroker,
-        last_time_active = os:timestamp()
+        last_time_active = erlang:monotonic_time(microsecond)
     },
 
     case lists:member(ProtoVer, AllowedProtocolVersions) of
@@ -780,8 +777,8 @@ connected(
         username = UserName
     } = State
 ) ->
-    Now = os:timestamp(),
-    case timer:now_diff(Now, Last) > (1500000 * KeepAlive) of
+    Now = erlang:monotonic_time(microsecond),
+    case (Now - Last) > (1500000 * KeepAlive) of
         true ->
             lager:warning("client ~p with username ~p stopped due to keepalive expired", [
                 SubscriberId, UserName
@@ -1949,7 +1946,7 @@ do_throttle(_, #state{max_message_rate = Rate}) ->
     end.
 
 set_last_time_active(true, State) ->
-    Now = os:timestamp(),
+    Now = erlang:monotonic_time(microsecond),
     State#state{last_time_active = Now};
 set_last_time_active(false, State) ->
     State.

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -33,8 +33,6 @@
 
 -define(DELAYED_PUBACK_TBL, vmq_delayed_puback_table).
 
--type timestamp() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}.
-
 -record(state, {
     %% mqtt layer requirements
     next_msg_id = undefined :: undefined | msg_id(),
@@ -55,8 +53,7 @@
     proto_ver :: undefined | pos_integer(),
     queue_pid :: pid() | undefined,
 
-    last_time_active = os:timestamp() :: timestamp(),
-    last_trigger = os:timestamp() :: timestamp(),
+    last_time_active = erlang:monotonic_time(microsecond) :: integer(),
 
     %% session tracking
     session_id :: undefined | binary(),
@@ -98,7 +95,7 @@ init(
         proto_ver = ProtoVer
     } = ConnectFrame
 ) ->
-    rand:seed(exsplus, os:timestamp()),
+    rand:seed(exsplus),
     MountPoint = proplists:get_value(mountpoint, Opts, ""),
     SubscriberId = {string:strip(MountPoint, right, $/), undefined},
     AllowedProtocolVersions = proplists:get_value(
@@ -580,8 +577,8 @@ connected(
         username = UserName
     } = State
 ) ->
-    Now = os:timestamp(),
-    case timer:now_diff(Now, Last) > (1500000 * KeepAlive) of
+    Now = erlang:monotonic_time(microsecond),
+    case (Now - Last) > (1500000 * KeepAlive) of
         true ->
             lager:warning("client ~p with username ~p stopped due to keepalive expired", [
                 SubscriberId, UserName
@@ -1591,7 +1588,7 @@ do_throttle(_, #state{max_message_rate = Rate}) ->
 
 -spec set_last_time_active(boolean(), state()) -> state().
 set_last_time_active(true, State) ->
-    Now = os:timestamp(),
+    Now = erlang:monotonic_time(microsecond),
     State#state{last_time_active = Now};
 set_last_time_active(false, State) ->
     State.
@@ -1631,22 +1628,22 @@ set_retry(MsgTag, MsgId, Interval, RetryQueue) ->
         true ->
             %% no waiting ack
             vmq_mqtt_fsm_util:send_after(Interval, retry),
-            Now = os:timestamp(),
+            Now = erlang:monotonic_time(microsecond),
             queue:in({Now, {MsgTag, MsgId}}, RetryQueue);
         false ->
-            Now = os:timestamp(),
+            Now = erlang:monotonic_time(microsecond),
             queue:in({Now, {MsgTag, MsgId}}, RetryQueue)
     end.
 
 handle_retry(Interval, RetryQueue, WAcks) ->
     %% the fired timer was set for the oldest element in the queue!
-    Now = os:timestamp(),
+    Now = erlang:monotonic_time(microsecond),
     handle_retry(Now, Interval, queue:out(RetryQueue), WAcks, []).
 
 handle_retry(
     Now, Interval, {{value, {Ts, {MsgTag, MsgId} = RetryId} = Val}, RetryQueue}, WAcks, Acc
 ) ->
-    NowDiff = timer:now_diff(Now, Ts) div 1000,
+    NowDiff = (Now - Ts) div 1000,
     case NowDiff < Interval of
         true ->
             vmq_mqtt_fsm_util:send_after(Interval - NowDiff, retry),


### PR DESCRIPTION
## Proposed Changes

This change is from vanilla VerneMQ

- v3 and v5 FSMs: replace os:timestamp() with erlang:monotonic_time(microsecond) for keepalive and retry timing
- Remove unused last_trigger field and timestamp() type from both FSMs
- rand:seed(exsplus) without os timestamp seed (upstream OTP change)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)