### PR TITLE
feat: ensure utf8 on connect fields

### DIFF
--- a/apps/vmq_commons/src/vmq_parser.erl
+++ b/apps/vmq_commons/src/vmq_parser.erl
@@ -170,32 +170,37 @@ variable(
         % reserved
         0:1, KeepAlive:16/big, ClientIdLen:16/big, ClientId:ClientIdLen/binary, Rest0/binary>>
 ) ->
-    Conn0 = #mqtt_connect{
-        proto_ver = ProtoVersion,
-        clean_session = CleanSession,
-        keep_alive = KeepAlive,
-        client_id = ClientId
-    },
+    case ensure_utf8(ClientId) of
+        {ok, ClientId0} ->
+            Conn0 = #mqtt_connect{
+                proto_ver = ProtoVersion,
+                clean_session = CleanSession,
+                keep_alive = KeepAlive,
+                client_id = ClientId0
+            },
 
-    case parse_last_will_topic(Rest0, WillFlag, WillRetain, WillQos, Conn0) of
-        {ok, Rest1, Conn1} ->
-            case parse_username(Rest1, UserNameFlag, Conn1) of
-                {ok, Rest2, Conn2} ->
-                    case parse_password(Rest2, UserNameFlag, PasswordFlag, Conn2) of
-                        {ok, <<>>, Conn3} ->
-                            Conn3;
-                        {ok, Rest3, Conn3} ->
-                            case vmq_parser_mqtt5:parse_properties(Rest3, #{}) of
-                                #{p_user_property := UserProps} = Props ->
-                                    %% Make sure to preserve order of the user properties
-                                    Conn3#mqtt_connect{
-                                        properties = Props#{
-                                            p_user_property => lists:reverse(UserProps)
-                                        }
-                                    };
-                                Properties when is_map(Properties) ->
-                                    Conn3#mqtt_connect{properties = Properties};
-                                {error, _} = E ->
+            case parse_last_will_topic(Rest0, WillFlag, WillRetain, WillQos, Conn0) of
+                {ok, Rest1, Conn1} ->
+                    case parse_username(Rest1, UserNameFlag, Conn1) of
+                        {ok, Rest2, Conn2} ->
+                            case parse_password(Rest2, UserNameFlag, PasswordFlag, Conn2) of
+                                {ok, <<>>, Conn3} ->
+                                    Conn3;
+                                {ok, Rest3, Conn3} ->
+                                    case vmq_parser_mqtt5:parse_properties(Rest3, #{}) of
+                                        #{p_user_property := UserProps} = Props ->
+                                            %% Make sure to preserve order of the user properties
+                                            Conn3#mqtt_connect{
+                                                properties = Props#{
+                                                    p_user_property => lists:reverse(UserProps)
+                                                }
+                                            };
+                                        Properties when is_map(Properties) ->
+                                            Conn3#mqtt_connect{properties = Properties};
+                                        {error, _} = E ->
+                                            E
+                                    end;
+                                E ->
                                     E
                             end;
                         E ->
@@ -245,7 +250,12 @@ parse_last_will_topic(_, _, _, _, _) ->
 parse_username(Rest, 0, Conn) ->
     {ok, Rest, Conn};
 parse_username(<<Len:16/big, UserName:Len/binary, Rest/binary>>, 1, Conn) ->
-    {ok, Rest, Conn#mqtt_connect{username = UserName}};
+    case ensure_utf8(UserName) of
+        {ok, UserName0} ->
+            {ok, Rest, Conn#mqtt_connect{username = UserName0}};
+        E ->
+            E
+    end;
 parse_username(_, 1, _) ->
     {error, cant_parse_username}.
 
@@ -269,22 +279,32 @@ parse_topics(
 ) when
     (QoS >= 0) and (QoS < 3)
 ->
-    case vmq_topic:validate_topic(subscribe, Topic) of
-        {ok, ParsedTopic} ->
-            T = #mqtt_subscribe_topic{
-                topic = ParsedTopic,
-                qos = QoS,
-                non_retry = to_bool(NonRetry),
-                non_persistence = to_bool(NonPersistence)
-            },
-            parse_topics(Rest, Sub, [T | Acc]);
+    case ensure_utf8(Topic) of
+        {ok, Topic0} ->
+            case vmq_topic:validate_topic(subscribe, Topic0) of
+                {ok, ParsedTopic} ->
+                    T = #mqtt_subscribe_topic{
+                        topic = ParsedTopic,
+                        qos = QoS,
+                        non_retry = to_bool(NonRetry),
+                        non_persistence = to_bool(NonPersistence)
+                    },
+                    parse_topics(Rest, Sub, [T | Acc]);
+                E ->
+                    E
+            end;
         E ->
             E
     end;
 parse_topics(<<L:16/big, Topic:L/binary, Rest/binary>>, ?UNSUBSCRIBE = Sub, Acc) ->
-    case vmq_topic:validate_topic(subscribe, Topic) of
-        {ok, ParsedTopic} ->
-            parse_topics(Rest, Sub, [ParsedTopic | Acc]);
+    case ensure_utf8(Topic) of
+        {ok, Topic0} ->
+            case vmq_topic:validate_topic(subscribe, Topic0) of
+                {ok, ParsedTopic} ->
+                    parse_topics(Rest, Sub, [ParsedTopic | Acc]);
+                E ->
+                    E
+            end;
         E ->
             E
     end;
@@ -462,6 +482,12 @@ utf8(IoList) when is_list(IoList) ->
     [<<(iolist_size(IoList)):16/big>>, IoList];
 utf8(Bin) when is_binary(Bin) ->
     <<(byte_size(Bin)):16/big, Bin/binary>>.
+
+ensure_utf8(Bin) when is_binary(Bin) ->
+    case unicode:characters_to_binary(Bin, utf8, utf8) of
+        {error, _, _} -> {error, invalid_utf8_string};
+        X -> {ok, X}
+    end.
 
 ensure_binary(L) when is_list(L) -> list_to_binary(L);
 ensure_binary(B) when is_binary(B) -> B;

--- a/apps/vmq_commons/src/vmq_parser_mqtt5.erl
+++ b/apps/vmq_commons/src/vmq_parser_mqtt5.erl
@@ -295,23 +295,28 @@ variable(
             %% Parse the payload.
             case Rest1 of
                 <<ClientIdLen:16/big, ClientId:ClientIdLen/binary, Rest2/binary>> ->
-                    case parse_will_properties(Rest2, Flags) of
-                        #{
-                            lwt := LWT,
-                            username := Username,
-                            password := Password
-                        } ->
-                            #mqtt5_connect{
-                                proto_ver = ?PROTOCOL_5,
-                                username = Username,
-                                password = Password,
-                                clean_start = CleanStart == 1,
-                                keep_alive = KeepAlive,
-                                client_id = ClientId,
-                                lwt = LWT,
-                                properties = Properties
-                            };
-                        {error, _} = E ->
+                    case ensure_utf8(ClientId) of
+                        {ok, ClientId0} ->
+                            case parse_will_properties(Rest2, Flags) of
+                                #{
+                                    lwt := LWT,
+                                    username := Username,
+                                    password := Password
+                                } ->
+                                    #mqtt5_connect{
+                                        proto_ver = ?PROTOCOL_5,
+                                        username = Username,
+                                        password = Password,
+                                        clean_start = CleanStart == 1,
+                                        keep_alive = KeepAlive,
+                                        client_id = ClientId0,
+                                        lwt = LWT,
+                                        properties = Properties
+                                    };
+                                {error, _} = E ->
+                                    E
+                            end;
+                        E ->
                             E
                     end;
                 _ ->
@@ -390,7 +395,12 @@ parse_username(Rest, <<0:1, _:5>> = Flags, M) ->
     %% Username bit is zero, no username.
     parse_password(Rest, Flags, M#{username => undefined});
 parse_username(<<Len:16/big, UserName:Len/binary, Rest/binary>>, <<1:1, _:5>> = Flags, M) ->
-    parse_password(Rest, Flags, M#{username => UserName});
+    case ensure_utf8(UserName) of
+        {ok, UserName0} ->
+            parse_password(Rest, Flags, M#{username => UserName0});
+        E ->
+            E
+    end;
 parse_username(_, _, _) ->
     %% FIXME: return correct error here
     {error, cant_parse_username}.
@@ -414,23 +424,33 @@ parse_topics(
 ) when
     (QoS >= 0), (QoS < 3), RetainHandling < 3
 ->
-    case vmq_topic:validate_topic(subscribe, Topic) of
-        {ok, ParsedTopic} ->
-            T = #mqtt5_subscribe_topic{
-                topic = ParsedTopic,
-                qos = QoS,
-                no_local = to_bool(NL),
-                rap = to_bool(Rap),
-                retain_handling = sub_retain_handling(RetainHandling)
-            },
-            parse_topics(Rest, Sub, [T | Acc]);
+    case ensure_utf8(Topic) of
+        {ok, Topic0} ->
+            case vmq_topic:validate_topic(subscribe, Topic0) of
+                {ok, ParsedTopic} ->
+                    T = #mqtt5_subscribe_topic{
+                        topic = ParsedTopic,
+                        qos = QoS,
+                        no_local = to_bool(NL),
+                        rap = to_bool(Rap),
+                        retain_handling = sub_retain_handling(RetainHandling)
+                    },
+                    parse_topics(Rest, Sub, [T | Acc]);
+                E ->
+                    E
+            end;
         E ->
             E
     end;
 parse_topics(<<L:16/big, Topic:L/binary, Rest/binary>>, ?UNSUBSCRIBE = Sub, Acc) ->
-    case vmq_topic:validate_topic(subscribe, Topic) of
-        {ok, ParsedTopic} ->
-            parse_topics(Rest, Sub, [ParsedTopic | Acc]);
+    case ensure_utf8(Topic) of
+        {ok, Topic0} ->
+            case vmq_topic:validate_topic(subscribe, Topic0) of
+                {ok, ParsedTopic} ->
+                    parse_topics(Rest, Sub, [ParsedTopic | Acc]);
+                E ->
+                    E
+            end;
         E ->
             E
     end;
@@ -695,6 +715,12 @@ utf8(IoList) when is_list(IoList) ->
     [<<(iolist_size(IoList)):16/big>>, IoList];
 utf8(Bin) when is_binary(Bin) ->
     <<(byte_size(Bin)):16/big, Bin/binary>>.
+
+ensure_utf8(Bin) when is_binary(Bin) ->
+    case unicode:characters_to_binary(Bin, utf8, utf8) of
+        {error, _, _} -> {error, invalid_utf8_string};
+        X -> {ok, X}
+    end.
 
 binary(X) ->
     %% We encode MQTT binaries the same as utf8, but use this function


### PR DESCRIPTION
## Proposed Changes

This change is added from vanilla vernemq

- validate client_id, username, and subscribe/unsubscribe topics as well-formed UTF8 via ensure_utf8/1 in vmq_parser and vmq_parser_mqtt5.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)