### PR TITLE
feat: Add simple options to HTTP health endpoint

### DIFF
--- a/apps/vmq_server/src/vmq_health_http.erl
+++ b/apps/vmq_server/src/vmq_health_http.erl
@@ -20,18 +20,49 @@
 -export([init/2]).
 
 routes() ->
-    [{"/health", ?MODULE, []}].
+    [
+        {"/health", ?MODULE, []},
+        {"/health/ping", ?MODULE, []},
+        {"/health/listeners", ?MODULE, []},
+        {"/health/listeners_full_cluster", ?MODULE, []}
+    ].
 
 init(Req, Opts) ->
+    Path = cowboy_req:path(Req),
     {Code, Payload} =
-        case check_health_concerns() of
-            [] ->
+        case Path of
+            <<"/health/ping">> ->
                 {200, [{<<"status">>, <<"OK">>}]};
-            Concerns ->
-                {503, [
-                    {<<"status">>, <<"DOWN">>},
-                    {<<"reasons">>, Concerns}
-                ]}
+            <<"/health">> ->
+                case check_health_concerns() of
+                    [] ->
+                        {200, [{<<"status">>, <<"OK">>}]};
+                    Concerns ->
+                        {503, [
+                            {<<"status">>, <<"DOWN">>},
+                            {<<"reasons">>, Concerns}
+                        ]}
+                end;
+            <<"/health/listeners">> ->
+                case listeners_status() of
+                    ok ->
+                        {200, [{<<"status">>, <<"OK">>}]};
+                    {error, Reason} ->
+                        {503, [
+                            {<<"status">>, <<"DOWN">>},
+                            {<<"reason">>, Reason}
+                        ]}
+                end;
+            <<"/health/listeners_full_cluster">> ->
+                case check_full_health_concerns() of
+                    [] ->
+                        {200, [{<<"status">>, <<"OK">>}]};
+                    Concerns ->
+                        {503, [
+                            {<<"status">>, <<"DOWN">>},
+                            {<<"reasons">>, Concerns}
+                        ]}
+                end
         end,
     Headers = #{<<"content-type">> => <<"application/json">>},
     cowboy_req:reply(Code, Headers, jsx:encode(Payload), Req),
@@ -87,3 +118,32 @@ listeners_status() ->
         Listeners ->
             {error, io_lib:format("Listeners are not ready: ~p", [Listeners])}
     end.
+
+cluster_full_status() ->
+    try
+        case vmq_cluster_mon:status() of
+            [] ->
+                {error, "Unknown cluster status"};
+            Status ->
+                case lists:member(false, [Online || {_Node, Online} <- Status]) of
+                    false -> ok;
+                    true -> {error, "At least one node is offline"}
+                end
+        end
+    catch
+        Exception:Reason ->
+            lager:debug("Cluster status check failed ~p:~p", [Exception, Reason]),
+            {error, "Unknown cluster status"}
+    end.
+
+-spec check_full_health_concerns() -> [] | [Concern :: string()].
+check_full_health_concerns() ->
+    lists:filtermap(
+        fun(Status) ->
+            case Status of
+                ok -> false;
+                {error, Reason} -> {true, list_to_binary(Reason)}
+            end
+        end,
+        [cluster_full_status(), listeners_status()]
+    ).


### PR DESCRIPTION
## Proposed Changes

This change is added from the vanilla VerneMQ
- add /health/ping, /health/listeners, and /health/listeners_full_cluster routes to the HTTP health listener.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)