### PR TITLE
fix: QoS0 offline queue_unhandled metric

### DIFF
--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -1578,7 +1578,7 @@ counter_entries_def() ->
             [],
             queue_message_unhandled,
             queue_message_unhandled,
-            <<"The number of unhandled messages when connecting with clean session=true.">>
+            <<"The number of unhandled messages when connecting with clean session=true or QoS0 for offline sessions.">>
         ),
         m(
             counter,

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -1129,6 +1129,7 @@ insert(
     Sessions == #{}
 ->
     %% no session online, skip message for QoS0 Subscription
+    _ = vmq_metrics:incr_queue_unhandled(1),
     on_message_drop_hook(SId, D, ?USER_OFFLINE, SessionId),
     State;
 insert(#deliver{msg = #vmq_msg{non_persistence = true}}, #state{sessions = Sessions} = State) when
@@ -1144,6 +1145,7 @@ insert(
     Sessions == #{}
 ->
     %% no session online, skip QoS0 message for QoS1 or QoS2 Subscription
+    _ = vmq_metrics:incr_queue_unhandled(1),
     on_message_drop_hook(SId, D, ?USER_OFFLINE, SessionId),
     State;
 insert(


### PR DESCRIPTION
## Proposed Changes

This change is added from vanilla VerneMQ
increment queue_message_unhandled when offline QoS0 publishes are dropped (no session online).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)