### PR TITLE
feat: will delay modifier and invalid modifier logging

### DIFF
--- a/apps/vmq_plugin/src/vmq_plugin_util.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_util.erl
@@ -37,6 +37,9 @@ check_modifiers(Hook, [{_, _} | _] = Modifiers) ->
             ({ModKey, ModVal}, Acc) ->
                 case lists:keyfind(ModKey, 1, AllowedModifiers) of
                     false ->
+                        lager:error("can't validate modifier ~p ~p (not an allowed modifier)", [
+                            Hook, ModKey
+                        ]),
                         error;
                     {_, ValidatorFun} ->
                         case ValidatorFun(ModVal) of
@@ -92,7 +95,8 @@ modifiers(auth_on_publish_m5) ->
                 {?P_CONTENT_TYPE, fun val_utf8/1},
                 {?P_PAYLOAD_FORMAT_INDICATOR, val_atoms_fun([utf8, undefined])},
                 {?P_RESPONSE_TOPIC, fun val_pub_topic/1},
-                {?P_CORRELATION_DATA, fun val_utf8/1}
+                {?P_CORRELATION_DATA, fun val_utf8/1},
+                {?P_WILL_DELAY_INTERVAL, fun val_int/1}
             ])}
         | modifiers(auth_on_publish)
     ];


### PR DESCRIPTION
## Proposed Changes

This change is added from vanilla VerneMQ
Allow overriding last will delay in plugins and improve error logging for invalid hook modifiers.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)