### PR TITLE
feat: mqtt v5 WS/SSL defaults and dev_n build vars

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -762,8 +762,7 @@
 %% - listener.wss.default = 127.0.0.1:880
 {mapping, "listener.tcp.$name", "vmq_server.listeners", [
                                                             {default, { "{{mqtt_default_ip}}", {{mqtt_default_port}} }},
-                                                            {datatype, ip},
-                                                            {include_default, "default"}
+                                                            {datatype, ip}
                                                            ]}.
 
 {mapping, "listener.ws.$name", "vmq_server.listeners", [
@@ -779,9 +778,8 @@
                                                                  ]}.
 
 {mapping, "listener.ssl.$name", "vmq_server.listeners", [
-                                                            {default, { "{{mqtt_default_ip}}", {{mqtt_default_port}} }},
-                                                            {datatype, ip},
-                                                            hidden
+                                                            {commented, { "{{mqtts_default_ip}}", {{mqtts_default_port}} }},
+                                                            {datatype, ip}
                                                            ]}.
 
 %% @doc listener.tcp.proxy_protocol specifies if the listener accepts
@@ -898,7 +896,7 @@
 
 {mapping, "listener.ws.allowed_protocol_versions", "vmq_server.listeners",
  [
-  {default, "3,4,131"},
+  {default, "3,4,5,131"},
   {datatype, string},
   hidden
  ]}.
@@ -911,7 +909,7 @@
 
 {mapping, "listener.wss.allowed_protocol_versions", "vmq_server.listeners",
  [
-  {default, "3,4,131"},
+  {default, "3,4,5,131"},
   {datatype, string},
   hidden
  ]}.
@@ -924,7 +922,7 @@
 
 {mapping, "listener.ssl.allowed_protocol_versions", "vmq_server.listeners",
  [
-  {default, "3,4,131"},
+  {default, "3,4,5,131"},
   {datatype, string},
   hidden
  ]}.
@@ -959,7 +957,7 @@
                                                                     ]}.
 
 {mapping, "listener.https.$name", "vmq_server.listeners", [
-                                                          {default, { "{{http_default_ip}}", {{http_default_port}} }},
+                                                          {default, { "{{https_default_ip}}", {{https_default_port}} }},
                                                           {datatype, ip},
                                                           hidden
                                                          ]}.

--- a/files/vmq.schema
+++ b/files/vmq.schema
@@ -16,6 +16,9 @@
   {default, "vmq"}
 ]}.
 
+{mapping, "nodename" , "vm_args.-name", [
+                 {default, "{{nodename}}"}
+                ]}.
 
 %% @doc Where to emit the default log messages (typically at 'info'
 %% severity):

--- a/gen_dev
+++ b/gen_dev
@@ -14,13 +14,17 @@ NUMBER=${NAME##dev}
 BASE=$((10000 + 50 * $NUMBER))
 MQTTPORT=$(($BASE + 3))
 MQTTWSPORT=$(($BASE + 4))
+MQTTSPORT=$(($BASE + 5))
 CLUSTERPORT=$(($BASE + 10))
 METRICSPORT=$(($BASE + 20))
+HTTPSPORT=$(($BASE + 21))
 
 
 echo "Generating $NAME - node='$NODE' mqttport=$MQTTPORT mqttwsport=$MQTTWSPORT"
 sed -e "s/@NODE@/$NODE/" \
     -e "s/@MQTTPORT@/$MQTTPORT/" \
     -e "s/@MQTTWSPORT@/$MQTTWSPORT/" \
+    -e "s/@MQTTSPORT@/$MQTTSPORT/" \
     -e "s/@CLUSTERPORT@/$CLUSTERPORT/" \
+    -e "s/@HTTPSPORT@/$HTTPSPORT/" \
     -e "s/@METRICSPORT@/$METRICSPORT/" < $TEMPLATE > $VARFILE

--- a/vars.config
+++ b/vars.config
@@ -31,16 +31,23 @@
 {runner_ulimit_warn, 65536}.
 
 %% vmq_server
+{nodename, "VerneMQ@127.0.0.1"}.
 {max_connections, 10000}.
 {max_nr_of_acceptors, 10}.
 {mqtt_default_ip, "127.0.0.1"}.
 {mqtt_default_port, 1883}.
 {mqtt_default_ws_ip, "127.0.0.1"}.
 {mqtt_default_ws_port, 8080}.
+{mqtts_default_ip, "127.0.0.1"}.
+{mqtts_default_port, 8883}.
 {cluster_default_ip, "0.0.0.0"}.
 {cluster_default_port, 44053}.
+{cluster_ssl_default_ip, "0.0.0.0"}.
+{cluster_ssl_default_port, 44054}.
 {http_default_ip, "127.0.0.1"}.
 {http_default_port, 8888}.
+{https_default_ip, "127.0.0.1"}.
+{https_default_port, "8889"}.
 
 %% lager
 {console_log_default, file}.

--- a/vars/dev_vars.config.src
+++ b/vars/dev_vars.config.src
@@ -32,16 +32,23 @@
 {runner_ulimit_warn,    65536}.
 
 %% vmq_server
+{nodename, "@NODE@"}.
 {max_connections, 10000}.
 {max_nr_of_acceptors, 10}.
 {mqtt_default_ip, "127.0.0.1"}.
 {mqtt_default_port, @MQTTPORT@}.
 {mqtt_default_ws_ip, "127.0.0.1"}.
 {mqtt_default_ws_port, @MQTTWSPORT@}.
+{mqtts_default_ip, "127.0.0.1"}.
+{mqtts_default_port, @MQTTSPORT@}.
 {cluster_default_ip, "0.0.0.0"}.
 {cluster_default_port, @CLUSTERPORT@}.
-{http_default_ip, "0.0.0.0"}.
+{cluster_ssl_default_ip, "0.0.0.0"}.
+{cluster_ssl_default_port, 44054}.
+{http_default_ip, "127.0.0.1"}.
 {http_default_port, @METRICSPORT@}.
+{https_default_ip, "127.0.0.1"}.
+{https_default_port, @HTTPSPORT@}.
 
 %% lager
 {console_log_default, both}.


### PR DESCRIPTION
## Proposed Changes

enable MQTT v5 by default on WS/WSS/SSL listeners, fix dev_n build vars (mqtts/https ports, nodename), and correct https listener defaults.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)
