### PR TITLE
feat: override max online messages

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -329,6 +329,13 @@
                                                     {datatype, integer}
                                                  ]}.
 
+%% @doc Allows a session that changes from offline to online to override the maximum
+%% online message count (max_online_messages). All offline messages will be added
+%% to the online queue.
+{mapping, "override_max_online_messages", "vmq_server.override_max_online_messages", [{default, off},
+                                                  {datatype, flag}
+                                                  ]}.
+
 %% @doc specify in case multiple sessions are allowed how the queue should
 %% deliver the messages. In case of 'fanout' all the attached sessions
 %% will receive the message, in case of 'balance' an attached session is

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -39,6 +39,7 @@ register_config_() ->
             "max_inflight_messages",
             "max_online_messages",
             "max_offline_messages",
+            "override_max_online_messages",
             "queue_deliver_mode",
             "queue_type",
             "max_message_rate",

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -84,6 +84,7 @@
     backup = queue:new(),
     type = fifo,
     max,
+    ignore_max = false,
     size = 0,
     drop = 0
 }).
@@ -276,7 +277,7 @@ online({set_opts, SessionPid, Opts}, _From, #state{opts = OldOpts} = State) ->
 online({add_session, SessionPid, #{allow_multiple_sessions := true} = Opts}, _From, State0) ->
     %% allow multiple sessions per queue
     RetOpts = #{initial_msg_id => State0#state.initial_msg_id},
-    State1 = unset_timers(add_session_(SessionPid, Opts, State0)),
+    State1 = unset_timers(add_session_(SessionPid, Opts, State0, false)),
     {reply, {ok, RetOpts}, online, State1};
 online({add_session, SessionPid, #{allow_multiple_sessions := false} = Opts}, From, State) when
     State#state.waiting_call == undefined
@@ -554,7 +555,7 @@ offline(Event, State) ->
 offline({add_session, SessionPid, Opts}, _From, State) ->
     ReturnOpts = #{initial_msg_id => State#state.initial_msg_id},
     {reply, {ok, ReturnOpts}, state_change(add_session, offline, online),
-        unset_timers(add_session_(SessionPid, Opts, State))};
+        unset_timers(add_session_(SessionPid, Opts, State, true))};
 offline({migrate, OtherQueue}, From, State) ->
     gen_fsm:send_event(self(), drain_start),
     {next_state, state_change(migrate, offline, drain), State#state{
@@ -835,7 +836,8 @@ add_session_(
         offline = Offline,
         sessions = Sessions,
         opts = OldOpts
-    } = State
+    } = State,
+    AllowExtendedQueueSize
 ) ->
     #{
         max_online_messages := MaxOnlineMessages,
@@ -846,6 +848,9 @@ add_session_(
     } = Opts,
     BatchSize = maps:get(queue_to_session_batch_size, Opts, 100),
     NewSessionId = maps:get(session_id, Opts, undefined),
+    AllowExtendedQueueSize0 =
+        AllowExtendedQueueSize andalso
+            application:get_env(vmq_server, override_max_online_messages, false),
     NewSessions =
         case maps:get(SessionPid, Sessions, not_found) of
             not_found ->
@@ -856,7 +861,9 @@ add_session_(
                     #session{
                         pid = SessionPid,
                         cleanup_on_disconnect = Clean,
-                        queue = #queue{max = MaxOnlineMessages},
+                        queue = #queue{
+                            max = MaxOnlineMessages, ignore_max = AllowExtendedQueueSize0
+                        },
                         started_at = vmq_time:timestamp(millisecond),
                         queue_to_session_batch_size = BatchSize
                     },
@@ -925,7 +932,7 @@ handle_session_down(
                     ])
             end,
             {next_state, state_change({'DOWN', add_session}, wait_for_offline, online),
-                add_session_(NewSessionPid, Opts, NewState#state{waiting_call = undefined})};
+                add_session_(NewSessionPid, Opts, NewState#state{waiting_call = undefined}, false)};
         {0, wait_for_offline, {migrate, _, From}} when
             DeletedSession#session.cleanup_on_disconnect
         ->
@@ -1109,7 +1116,24 @@ insert_from_queue(F, {{value, Msg}, Q}, State) when is_tuple(Msg) ->
     insert_from_queue(F, F(Q), insert(Msg, State));
 insert_from_queue(F, {{value, MsgRef}, Q}, State) when is_binary(MsgRef) ->
     insert_from_queue(F, F(Q), insert(MsgRef, State));
-insert_from_queue(_F, {empty, _}, State) ->
+insert_from_queue(_F, {empty, _}, #state{sessions = #{}} = State) ->
+    State;
+insert_from_queue(_F, {empty, _}, #state{sessions = Sessions} = State) ->
+    reset_ignore_max(maps:keys(Sessions), State).
+
+reset_ignore_max([SessionPid | Rest], #state{sessions = Sessions} = State) ->
+    #session{queue = Queue} = Session = maps:get(SessionPid, Sessions),
+    NewSessions = maps:update(
+        SessionPid,
+        Session#session{
+            queue = Queue#queue{
+                ignore_max = false
+            }
+        },
+        Sessions
+    ),
+    reset_ignore_max(Rest, State#state{sessions = NewSessions});
+reset_ignore_max([], State) ->
     State.
 
 insert_many(MsgsOrRefs, State) ->
@@ -1201,6 +1225,10 @@ session_insert(SId, #session{status = notify, queue = Q} = Session, MsgOrRef, Se
 
 %% unlimited messages accepted
 queue_insert(Offline, MsgOrRef, #queue{max = -1, size = Size, queue = Queue} = Q, SId, _SessionId) ->
+    Q#queue{queue = queue:in(maybe_offline_store(Offline, SId, MsgOrRef), Queue), size = Size + 1};
+queue_insert(
+    Offline, MsgOrRef, #queue{ignore_max = true, size = Size, queue = Queue} = Q, SId, _SessionId
+) ->
     Q#queue{queue = queue:in(maybe_offline_store(Offline, SId, MsgOrRef), Queue), size = Size + 1};
 %% tail drop in case of fifo
 queue_insert(

--- a/apps/vmq_server/test/vmq_queue_SUITE.erl
+++ b/apps/vmq_server/test/vmq_queue_SUITE.erl
@@ -22,6 +22,9 @@
          queue_fifo_offline_drop_test/1,
          queue_lifo_offline_drop_test/1,
          queue_offline_transition_test/1,
+         queue_offline_online_transition_test_std/1,
+         queue_offline_online_transition_test_ignore_max/1,
+         queue_offline_online_transition_test_ignore_max_lifo/1,
          queue_persistent_client_expiration_test/1,
          queue_force_disconnect_test/1,
          queue_force_disconnect_cleanup_test/1]).
@@ -63,6 +66,9 @@ groups() ->
      queue_fifo_offline_drop_test,
      queue_lifo_offline_drop_test,
      queue_offline_transition_test,
+     queue_offline_online_transition_test_std,
+     queue_offline_online_transition_test_ignore_max,
+     queue_offline_online_transition_test_ignore_max_lifo,
      queue_persistent_client_expiration_test,
      queue_force_disconnect_test,
      queue_force_disconnect_cleanup_test
@@ -238,6 +244,82 @@ queue_offline_transition_test(Cfg) ->
     {ok, #{session_present := true,
            queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
     ok = receive_multi(QPid, 1, Msgs),
+    {ok, []} = vmq_message_store:find(SubscriberId).
+
+queue_offline_online_transition_test_std(Cfg) ->
+    #{group := RegView, tc := _} = proplists:get_value(vmq_md, Cfg),
+    Parent = self(),
+    SubscriberId = {"", <<"mock-trans-client-std">>},
+    application:set_env(vmq_server, override_max_online_messages, false),
+    QueueOpts = maps:merge(vmq_queue:default_opts(), #{cleanup_on_disconnect => false,
+                                                       max_offline_messages => 100,
+                                                       max_online_messages => 10,
+                                                       queue_type => fifo}),
+    SessionPid1 = spawn(fun() -> mock_session(Parent) end),
+    {ok, #{session_present := false,
+           queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, [1]} = vmq_reg:subscribe(SubscriberId, [{[<<"test">>, <<"transition">>], 1}]),
+    timer:sleep(20),
+
+    catch vmq_queue:set_last_waiting_acks(QPid, []),
+    SessionPid1 ! {go_down_in, 1},
+    Msgs = publish_multi(RegView, SubscriberId, [<<"test">>, <<"transition">>]),
+
+    SessionPid2 = spawn(fun() -> mock_session(Parent) end),
+    {ok, #{session_present := true,
+           queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    {KeptMsgs, _} = lists:split(10, Msgs),
+    ok = receive_multi(QPid, 1, KeptMsgs),
+    {ok, []} = vmq_message_store:find(SubscriberId).
+
+queue_offline_online_transition_test_ignore_max(Cfg) ->
+    #{group := RegView, tc := _} = proplists:get_value(vmq_md, Cfg),
+    Parent = self(),
+    SubscriberId = {"", <<"mock-trans-client-ignore">>},
+    application:set_env(vmq_server, override_max_online_messages, true),
+    QueueOpts = maps:merge(vmq_queue:default_opts(), #{cleanup_on_disconnect => false,
+                                                       max_offline_messages => 100,
+                                                       max_online_messages => 10,
+                                                       queue_type => fifo}),
+    SessionPid1 = spawn(fun() -> mock_session(Parent) end),
+    {ok, #{session_present := false,
+           queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, [1]} = vmq_reg:subscribe(SubscriberId, [{[<<"test">>, <<"transition">>], 1}]),
+    timer:sleep(20),
+
+    catch vmq_queue:set_last_waiting_acks(QPid, []),
+    SessionPid1 ! {go_down_in, 1},
+    Msgs = publish_multi(RegView, SubscriberId, [<<"test">>, <<"transition">>]),
+
+    SessionPid2 = spawn(fun() -> mock_session(Parent) end),
+    {ok, #{session_present := true,
+           queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    ok = receive_multi(QPid, 1, Msgs),
+    {ok, []} = vmq_message_store:find(SubscriberId).
+
+queue_offline_online_transition_test_ignore_max_lifo(Cfg) ->
+    #{group := RegView, tc := _} = proplists:get_value(vmq_md, Cfg),
+    Parent = self(),
+    SubscriberId = {"", <<"mock-trans-client-lifo">>},
+    application:set_env(vmq_server, override_max_online_messages, true),
+    QueueOpts = maps:merge(vmq_queue:default_opts(), #{cleanup_on_disconnect => false,
+                                                       max_offline_messages => 100,
+                                                       max_online_messages => 10,
+                                                       queue_type => lifo}),
+    SessionPid1 = spawn(fun() -> mock_session(Parent) end),
+    {ok, #{session_present := false,
+           queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, [1]} = vmq_reg:subscribe(SubscriberId, [{[<<"test">>, <<"transition">>], 1}]),
+    timer:sleep(20),
+
+    catch vmq_queue:set_last_waiting_acks(QPid, []),
+    SessionPid1 ! {go_down_in, 1},
+    Msgs = publish_multi(RegView, SubscriberId, [<<"test">>, <<"transition">>]),
+
+    SessionPid2 = spawn(fun() -> mock_session(Parent) end),
+    {ok, #{session_present := true,
+           queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    ok = receive_multi(QPid, 1, lists:reverse(Msgs)),
     {ok, []} = vmq_message_store:find(SubscriberId).
 
 queue_persistent_client_expiration_test(Cfg) ->


### PR DESCRIPTION
## Proposed Changes

This change is added from vanilla VerneMQ
add override_max_online_messages config so offline-to-online queue transition can temporarily exceed max_online_messages.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)