### PR TITLE
fix: QoS0 persist on upgrade_qos

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -1080,7 +1080,7 @@ check_user(
                     connack_terminate(?BAD_USERNAME_OR_PASSWORD, State)
             end;
         true ->
-            QueueOpts = queue_opts([], Props),
+            QueueOpts = queue_opts([], Props, State),
             SessionExpiryInterval = maps:get(session_expiry_interval, QueueOpts, 0),
             register_subscriber(
                 F,
@@ -1315,7 +1315,7 @@ auth_on_register(Password, Props, State) ->
     HookArgs = [Peer, SubscriberId, User, Password, CleanStart, Props],
     case vmq_plugin:all_till_ok(auth_on_register_m5, HookArgs) of
         ok ->
-            {ok, queue_opts([], Props), #{}, State};
+            {ok, queue_opts([], Props, State), #{}, State};
         {ok, Args0} ->
             Args = maps:to_list(Args0),
             set_sock_opts(prop_val(tcp_opts, Args, [])),
@@ -1356,7 +1356,8 @@ auth_on_register(Password, Props, State) ->
                 topic_alias_max = ?state_val(topic_alias_max, Args, State),
                 topic_aliases_in = ?state_val(topic_aliases_in, Args, State)
             },
-            {ok, queue_opts(Args, maps:merge(Props, ChangedProps)), ChangedProps, ChangedState};
+            {ok, queue_opts(Args, maps:merge(Props, ChangedProps), ChangedState), ChangedProps,
+                ChangedState};
         {error, Reason} ->
             {error, Reason}
     end.
@@ -2019,9 +2020,9 @@ queue_opts_from_properties(Properties) ->
         Properties
     ).
 
-queue_opts(Args, Properties) ->
+queue_opts(Args, Properties, State) ->
     PropertiesOpts = queue_opts_from_properties(Properties),
-    Opts = maps:from_list(Args),
+    Opts = maps:from_list([{upgrade_qos, State#state.upgrade_qos} | Args]),
     Opts1 = maps:merge(PropertiesOpts, Opts),
     maps:merge(vmq_queue:default_opts(), Opts1).
 

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -1751,8 +1751,15 @@ prop_val(Key, Args, Default, Validator) ->
     end.
 
 -spec queue_opts(state(), [any()]) -> map().
-queue_opts(#state{clean_session = CleanSession, session_id = SessionId}, Args) ->
-    Opts = maps:from_list([{cleanup_on_disconnect, CleanSession}, {session_id, SessionId} | Args]),
+queue_opts(
+    #state{clean_session = CleanSession, session_id = SessionId, upgrade_qos = UpgradeQoS}, Args
+) ->
+    Opts = maps:from_list([
+        {cleanup_on_disconnect, CleanSession},
+        {session_id, SessionId},
+        {upgrade_qos, UpgradeQoS}
+        | Args
+    ]),
     maps:merge(vmq_queue:default_opts(), Opts).
 
 -spec unflag(boolean() | 0 | 1) -> boolean().

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -1146,11 +1146,12 @@ insert(#deliver{msg = #vmq_msg{non_persistence = true}}, #state{sessions = Sessi
     State;
 insert(
     #deliver{msg = #vmq_msg{qos = 0}} = D,
-    #state{id = SId, sessions = Sessions, session_id = SessionId} = State
+    #state{id = SId, sessions = Sessions, session_id = SessionId, opts = #{upgrade_qos := false}} =
+        State
 ) when
     Sessions == #{}
 ->
-    %% no session online, skip QoS0 message for QoS1 or QoS2 Subscription
+    %% no session online, skip QoS0 message for QoS1 or QoS2 Subscription (without QoS upgrade)
     _ = vmq_metrics:incr_queue_unhandled(1),
     on_message_drop_hook(SId, D, ?USER_OFFLINE, SessionId),
     State;


### PR DESCRIPTION
## Proposed Changes

This change is added from vanilla VerneMQ
pass upgrade_qos into queue opts so QoS0 messages persist to disk when upgrade_qos is enabled.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)