### PR TITLE
feat: max_header_value_length listener option

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -976,6 +976,50 @@
                                                                      hidden
                                                                     ]}.
 
+%% @doc The maximum length of the HTTP request in bytes (Cowboy's max_request_line_length)
+{mapping, "listener.http.$name.max_request_line_length", "vmq_server.listeners", [
+                                                                     {default, 8000},
+                                                                     {datatype, integer},
+                                                                     hidden
+                                                                    ]}.
+{mapping, "listener.https.$name.max_request_line_length", "vmq_server.listeners", [
+                                                                     {default, 8000},
+                                                                     {datatype, integer},
+                                                                     hidden
+                                                                    ]}.
+{mapping, "listener.ws.$name.max_request_line_length", "vmq_server.listeners", [
+                                                                     {default, 8000},
+                                                                     {datatype, integer},
+                                                                     hidden
+                                                                    ]}.
+{mapping, "listener.wss.$name.max_request_line_length", "vmq_server.listeners", [
+                                                                     {default, 8000},
+                                                                     {datatype, integer},
+                                                                     hidden
+                                                                    ]}.
+
+%% @doc The maximum length of the HTTP header in bytes (Cowboy's max_header_value_length)
+{mapping, "listener.http.$name.max_header_value_length", "vmq_server.listeners", [
+                                                                     {default, 4096},
+                                                                     {datatype, integer},
+                                                                     hidden
+                                                                    ]}.
+{mapping, "listener.https.$name.max_header_value_length", "vmq_server.listeners", [
+                                                                     {default, 4096},
+                                                                     {datatype, integer},
+                                                                     hidden
+                                                                    ]}.
+{mapping, "listener.ws.$name.max_header_value_length", "vmq_server.listeners", [
+                                                                     {default, 4096},
+                                                                     {datatype, integer},
+                                                                     hidden
+                                                                    ]}.
+{mapping, "listener.wss.$name.max_header_value_length", "vmq_server.listeners", [
+                                                                     {default, 4096},
+                                                                     {datatype, integer},
+                                                                     hidden
+                                                                    ]}.
+
 %% @doc listener.vmq.clustering is the IP address and TCP port that
 %% the broker will bind to accept connections from other cluster
 %% nodes e.g:

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -273,9 +273,13 @@ protocol_opts(vmq_ranch, _, Opts) ->
 protocol_opts(cowboy_clear, Type, Opts) when
     (Type == mqttws) or (Type == mqttwss)
 ->
+    MaxRequestLength = proplists:get_value(max_request_line_length, Opts, 8000),
+    MaxHeaderValueLength = proplists:get_value(max_header_value_length, Opts, 4096),
     #{
         env => #{dispatch => dispatch(Type, Opts)},
-        stream_handlers => [vmq_cowboy_websocket_h, cowboy_stream_h]
+        stream_handlers => [vmq_cowboy_websocket_h, cowboy_stream_h],
+        max_request_line_length => MaxRequestLength,
+        max_header_value_length => MaxHeaderValueLength
     };
 protocol_opts(cowboy_clear, _, Opts) ->
     Routes =
@@ -293,7 +297,13 @@ protocol_opts(cowboy_clear, _, Opts) ->
         end,
     CowboyRoutes = [{'_', Routes}],
     Dispatch = cowboy_router:compile(CowboyRoutes),
-    #{env => #{dispatch => Dispatch}};
+    MaxRequestLength = proplists:get_value(max_request_line_length, Opts, 8000),
+    MaxHeaderValueLength = proplists:get_value(max_header_value_length, Opts, 4096),
+    #{
+        env => #{dispatch => Dispatch},
+        max_request_line_length => MaxRequestLength,
+        max_header_value_length => MaxHeaderValueLength
+    };
 protocol_opts(vmq_cluster_com, _, Opts) ->
     Opts.
 

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -183,6 +183,31 @@ translate_listeners(Conf) ->
         extract("listener.vmq", "low_msgq_watermark", IntVal, Conf)
     ),
 
+    {HTTPIPs, HTTPMaxLengths} = lists:unzip(
+        extract("listener.http", "max_request_line_length", IntVal, Conf)
+    ),
+    {HTTP_SSLIPs, HTTP_SSLMaxLengths} = lists:unzip(
+        extract("listener.https", "max_request_line_length", IntVal, Conf)
+    ),
+    {WSIPs, WSMaxLengths} = lists:unzip(
+        extract("listener.ws", "max_request_line_length", IntVal, Conf)
+    ),
+    {WS_SSLIPs, WS_SSLMaxLengths} = lists:unzip(
+        extract("listener.wss", "max_request_line_length", IntVal, Conf)
+    ),
+    {HTTPIPs, HTTPHeaderLengths} = lists:unzip(
+        extract("listener.http", "max_header_value_length", IntVal, Conf)
+    ),
+    {HTTP_SSLIPs, HTTP_SSLHeaderLengths} = lists:unzip(
+        extract("listener.https", "max_header_value_length", IntVal, Conf)
+    ),
+    {WSIPs, WSHeaderLengths} = lists:unzip(
+        extract("listener.ws", "max_header_value_length", IntVal, Conf)
+    ),
+    {WS_SSLIPs, WS_SSLHeaderLengths} = lists:unzip(
+        extract("listener.wss", "max_header_value_length", IntVal, Conf)
+    ),
+
     {HTTPIPs, HTTPConfigMod} = lists:unzip(extract("listener.http", "config_mod", AtomVal, Conf)),
     {HTTPIPs, HTTPConfigFun} = lists:unzip(extract("listener.http", "config_fun", AtomVal, Conf)),
     {HTTP_SSLIPs, HTTP_SSLConfigMod} = lists:unzip(
@@ -267,7 +292,9 @@ translate_listeners(Conf) ->
             WSNrOfAcceptors,
             WSMountPoint,
             WSProxyProto,
-            WSAllowedProto
+            WSAllowedProto,
+            WSMaxLengths,
+            WSHeaderLengths
         ])
     ),
     VMQ = lists:zip(
@@ -290,7 +317,9 @@ translate_listeners(Conf) ->
             HTTPNrOfAcceptors,
             HTTPConfigMod,
             HTTPConfigFun,
-            HTTPProxyProto
+            HTTPProxyProto,
+            HTTPMaxLengths,
+            HTTPHeaderLengths
         ])
     ),
 
@@ -330,7 +359,9 @@ translate_listeners(Conf) ->
             WS_SSLRequireCerts,
             WS_SSLVersions,
             WS_SSLUseIdents,
-            WS_SSLAllowedProto
+            WS_SSLAllowedProto,
+            WS_SSLMaxLengths,
+            WS_SSLHeaderLengths
         ])
     ),
     HTTPS = lists:zip(
@@ -348,7 +379,9 @@ translate_listeners(Conf) ->
             HTTP_SSLRequireCerts,
             HTTP_SSLVersions,
             HTTP_SSLConfigMod,
-            HTTP_SSLConfigFun
+            HTTP_SSLConfigFun,
+            HTTP_SSLMaxLengths,
+            HTTP_SSLHeaderLengths
         ])
     ),
 
@@ -389,6 +422,8 @@ extract(Prefix, Suffix, Val, Conf) ->
             %% http listener specific
             "config_mod",
             "config_fun",
+            "max_request_line_length",
+            "max_header_value_length",
             %% mqtt listener specific
             "allowed_protocol_versions",
             %% other


### PR DESCRIPTION
## Proposed Changes

max_header_value_length and max_request_line_length for http(s) and ws(s) listeners.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)