### PR TITLE
fix: keep MQTT v5 connect username for allow_anonymous sessions

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -1086,7 +1086,7 @@ check_user(
                 F,
                 OutProps,
                 QueueOpts,
-                State#state{session_expiry_interval = SessionExpiryInterval}
+                State#state{session_expiry_interval = SessionExpiryInterval, username = User}
             )
     end.
 


### PR DESCRIPTION
## Proposed Changes

Fix MQTT v5 allow_anonymous username from CONNECT packet.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)