### PR TITLE
feat: listener suspension and nodetool IPv6 bootstrap

### DIFF
--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -204,7 +204,7 @@ reconfigure_listeners(Config) ->
         Config,
         vmq_config:get_env(listeners)
     ),
-    Listeners = supervisor:which_children(ranch_sup),
+    Listeners = ranch_server:get_listener_sups(),
     reconfigure_listeners(TCPListenOptions, ListenerConfig, Listeners).
 reconfigure_listeners(TCPListenOptions, [{T, Config} | Rest], Listeners) ->
     NewListeners = reconfigure_listeners_for_type(T, Config, TCPListenOptions, Listeners),

--- a/apps/vmq_server/src/vmq_server.erl
+++ b/apps/vmq_server/src/vmq_server.erl
@@ -16,7 +16,8 @@
 -export([
     start/0,
     start_no_auth/0,
-    stop/0
+    stop/0,
+    stop/1
 ]).
 
 -spec start_no_auth() -> 'ok'.
@@ -40,8 +41,30 @@ start() ->
 
 -spec stop() -> 'ok'.
 stop() ->
+    vmq_ranch_config:stop_all_mqtt_listeners(true),
     application:stop(vmq_server),
     wait_until_metadata_has_stopped(),
+    _ = [
+        application:stop(App)
+     || App <- [
+            vmq_plugin,
+            riak_sysmon,
+            clique,
+            asn1,
+            public_key,
+            cowboy,
+            ranch,
+            crypto,
+            ssl,
+            os_mon,
+            lager
+        ]
+    ],
+    ok.
+
+stop(no_wait) ->
+    vmq_ranch_config:stop_all_mqtt_listeners(true),
+    application:stop(vmq_server),
     _ = [
         application:stop(App)
      || App <- [

--- a/apps/vmq_server/src/vmq_server_app.erl
+++ b/apps/vmq_server/src/vmq_server_app.erl
@@ -27,6 +27,7 @@
 
 -spec start(_, _) -> {'error', _} | {'ok', pid()} | {'ok', pid(), _}.
 start(_StartType, _StartArgs) ->
+    maybe_update_nodetool(),
     case vmq_server_sup:start_link() of
         {error, _} = E ->
             E;
@@ -77,4 +78,34 @@ prep_stop(State) ->
 
 -spec stop(_) -> 'ok'.
 stop(_State) ->
+    ok = vmq_ranch_config:stop_all_mqtt_listeners(true),
+    _ = vmq_message_store:stop(),
+    _ = vmq_metadata:stop(),
     ok.
+
+maybe_update_nodetool() ->
+    case init:get_argument(proto_dist) of
+        {ok, [[ProtoDist]]} ->
+            Root = code:root_dir(),
+            Nodetool = filename:join([
+                Root, "erts-" ++ erlang:system_info(version), "bin", "nodetool"
+            ]),
+            case escript:extract(Nodetool, []) of
+                {ok, [Shebang, Comment, _, Source]} ->
+                    {ok, UpdatedScriptBin} =
+                        escript:create(binary, [
+                            Shebang, Comment, {emu_args, "+fnu -proto_dist " ++ ProtoDist}, Source
+                        ]),
+                    try file:write_file(Nodetool, UpdatedScriptBin) of
+                        ok -> ok
+                    catch
+                        E:R ->
+                            lager:info("Could not write nodetool due to ~p for reason ~p~n", [E, R]),
+                            {error, R}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        error ->
+            ignore
+    end.

--- a/apps/vmq_server/test/vmq_test_utils.erl
+++ b/apps/vmq_server/test/vmq_test_utils.erl
@@ -54,7 +54,7 @@ teardown(ClearRedis) ->
     end,
     disable_all_plugins(),
     vmq_metrics:reset_counters(),
-    vmq_server:stop(),
+    vmq_server:stop(no_wait),
     application:unload(vmq_server),
     Datadir = "/tmp/vernemq-test/data/" ++ atom_to_list(node()),
     _ = [eleveldb:destroy(Datadir ++ "/meta/" ++ integer_to_list(I), [])


### PR DESCRIPTION
## Proposed Changes

fix MQTT listener suspension and --kill_sessions during cluster leave, plus nodetool proto_dist bootstrap for IPv6 vmq-admin

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)