### PR TITLE
feat: reject auth data without auth method

### DIFF
--- a/apps/vmq_commons/src/vmq_parser_mqtt5.erl
+++ b/apps/vmq_commons/src/vmq_parser_mqtt5.erl
@@ -291,7 +291,7 @@ variable(
         Flags:6/bitstring, CleanStart:1, 0:1, KeepAlive:16/big, Rest0/binary>>
 ) ->
     %% The properties are the last element of the variable header.
-    case parse_properties(Rest0) of
+    case parse_connect_properties(Rest0) of
         {ok, Properties, Rest1} ->
             %% Parse the payload.
             case Rest1 of
@@ -951,6 +951,25 @@ gen_auth(RC, Properties) ->
             }
         )
     ).
+
+-spec parse_connect_properties(binary()) ->
+    {ok, map(), binary()}
+    | {error, any()}.
+parse_connect_properties(Data) ->
+    case parse_properties(Data) of
+        {ok, Properties, Rest1} when is_map(Properties) ->
+            case
+                {
+                    maps:is_key(p_authentication_data, Properties),
+                    maps:is_key(p_authentication_method, Properties)
+                }
+            of
+                {true, false} -> {error, authentication_data_without_authentication_method};
+                _ -> {ok, Properties, Rest1}
+            end;
+        E ->
+            E
+    end.
 
 -spec parse_properties(binary()) ->
     {ok, map(), binary()}

--- a/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
+++ b/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
@@ -48,6 +48,7 @@ groups() ->
      uname_password_denied,
      uname_password_success,
      change_subscriber_id,
+     auth_data_no_method,
      enhanced_authentication,
      enhanced_auth_no_other_packets,
      enhanced_auth_method_not_supported,
@@ -152,6 +153,14 @@ change_subscriber_id(_Config) ->
     %% TODO: should we be allowed to do this? If we should, should we
     %% then respond with the assigned_client_id property?
     {skip, not_implemented}.
+
+auth_data_no_method(_Config) ->
+    vmq_server_cmd:set_config(allow_anonymous, true),
+    vmq_config:configure_node(),
+    Connect = packetv5:gen_connect(<<"Client12">>, [{keepalive, 10},
+        {properties, #{p_authentication_data => <<"ThisIsNotValid">>}}]),
+    Connack = packetv5:gen_connack(),
+    {error, closed} = packetv5:do_client_connect(Connect, Connack, []).
 
 -define(AUTH_METHOD, <<"AuthMethod">>).
 


### PR DESCRIPTION
## Proposed Changes

reject CONNECT when authentication data is present without authentication method (MQTT v5 protocol error).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)