### PR TITLE
feat: plugin subscribe subinfo flags

### DIFF
--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -746,6 +746,9 @@ direct_plugin_exports(LogName, Opts) ->
             ([W | _] = Topic) when is_binary(W) ->
                 CallingPid = self(),
                 subscribe({Mountpoint, ClientId}, [{Topic, 0}]);
+            ({[W | _] = Topic, SubInfo}) when is_binary(W) ->
+                CallingPid = self(),
+                subscribe({Mountpoint, ClientId}, [{Topic, {0, SubInfo}}]);
             (_) ->
                 {error, invalid_topic}
         end,

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -106,7 +106,8 @@ groups() ->
             message_size_exceeded_close,
             shared_subscription_offline,
             shared_subscription_online_first,
-            direct_plugin_exports_test
+            direct_plugin_exports_test,
+            direct_plugin_exports_test_subinfo
         ],
     V3Tests =
         [
@@ -1456,6 +1457,52 @@ max_packet_size(Config) ->
     disable_on_subscribe(),
     disable_on_message_drop(),
     ok.
+
+direct_plugin_exports_test_subinfo(Cfg) ->
+    Topic = vmq_cth:utopic(Cfg),
+    WTopic = re:split(list_to_binary(Topic), <<"/">>),
+    {RegFun0, PubFun3, {SubFun1, UnsubFun1}} =
+        vmq_reg:direct_plugin_exports(?FUNCTION_NAME),
+    ok = RegFun0(),
+    {ok, [0]} = SubFun1({WTopic, #{rap => true}}),
+    %% this client-id generation is taken from
+    %% `vmq_reg:direct_plugin_exports/1`. It would be better if that
+    %% function would return the generated client-id.
+    ClientId = fun(T) ->
+        list_to_binary(
+            base64:encode_to_string(
+                integer_to_binary(
+                    erlang:phash2(T)
+                )
+            )
+        )
+    end,
+    TestSub =
+        fun(T, MustBePresent) ->
+            Subscribers = vmq_reg_trie:fold(
+                {"", ClientId(self())},
+                T,
+                fun(E, _From, Acc) -> [E | Acc] end,
+                []
+            ),
+            IsPresent = lists:member({{"", ClientId(self())}, 0}, Subscribers),
+            MustBePresent =:= IsPresent
+        end,
+    vmq_cluster_test_utils:wait_until(fun() -> TestSub(WTopic, true) end, 100, 10),
+    {ok, {1, 0}} = PubFun3(WTopic, <<"msg1">>, #{retain => true}),
+    receive
+        {deliver, WTopic, <<"msg1">>, 0, true, false} -> ok;
+        Other -> throw({received_unexpected_msg, Other})
+    after 1000 ->
+        throw(didnt_receive_expected_msg_from_direct_plugin_exports)
+    end,
+    ok = UnsubFun1(WTopic),
+    vmq_cluster_test_utils:wait_until(fun() -> TestSub(WTopic, false) end, 100, 10),
+    {ok, {0, 0}} = PubFun3(WTopic, <<"msg2">>, #{}),
+    receive
+        M -> throw({received_unexpected_msg_from_direct_plugin_exports, M})
+    after 100 -> ok
+    end.
 
 direct_plugin_exports_test(Cfg) ->
     Topic = vmq_cth:utopic(Cfg),


### PR DESCRIPTION
## Proposed Changes

- Allow plugin subscribe via direct_plugin_exports to pass SubInfo (e.g. #{rap => true})
- Adds direct_plugin_exports_test_subinfo integration test

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)