### PR TITLE
feat: skip non-persistent subs at boot

### DIFF
--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -771,10 +771,10 @@ subscribe_subscriber_changes() ->
 
 fold_subscriptions(FoldFun, Acc) ->
     fold_subscribers(
-        fun({MP, _} = SubscriberId, Subs, AAcc) ->
+        fun({MP, _} = SubscriberId, [{_, CleanSession, _}] = Subs, AAcc) ->
             vmq_subscriber:fold(
                 fun({Topic, QoS, Node}, AAAcc) ->
-                    FoldFun({MP, Topic, {SubscriberId, QoS, Node}}, AAAcc)
+                    FoldFun({MP, Topic, {SubscriberId, QoS, Node, CleanSession}}, AAAcc)
                 end,
                 AAcc,
                 Subs

--- a/apps/vmq_server/src/vmq_reg_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_trie.erl
@@ -249,8 +249,11 @@ handle_info(
         queue:to_list(Q)
     ),
     NrOfSubscribers = ets:info(vmq_trie_subs, size),
+    NrOfRemoteSubscribers = ets:info(vmq_trie_remote_subs, size),
     persistent_term:put(subscribe_trie_ready, 1),
-    lager:info("loaded ~p subscriptions into ~p", [NrOfSubscribers, ?MODULE]),
+    lager:info("loaded ~p local subscriptions and ~p remote subscriptions into ~p", [
+        NrOfSubscribers, NrOfRemoteSubscribers, ?MODULE
+    ]),
     {noreply, State#state{status = ready, event_queue = undefined}};
 handle_info(Event, #state{status = init, event_queue = Q} = State) ->
     {noreply, State#state{event_queue = queue:in(Event, Q)}};
@@ -352,15 +355,29 @@ match_(Topic, [{NodeOrGroup, _} | Rest], Acc) ->
 match_(_, [], Acc) ->
     Acc.
 
-initialize_trie({MP, [<<"$share">>, Group | Topic], {SubscriberId, SubInfo, Node}}, Acc) ->
+initialize_trie(
+    {_MP, [<<"$share">>, _Group | _Topic], {_SubscriberId, _SubInfo, Node, CleanSession}}, Acc
+) when
+    Node =:= node(), CleanSession == true
+->
+    Acc;
+initialize_trie(
+    {MP, [<<"$share">>, Group | Topic], {SubscriberId, SubInfo, Node, _CleanSession}}, Acc
+) ->
     add_complex_topic(MP, Topic, {Node, Group}, true),
     add_subscriber_group(MP, Node, Group, Topic, SubscriberId, SubInfo),
     Acc;
-initialize_trie({MP, Topic, {SubscriberId, SubInfo, Node}}, Acc) when Node =:= node() ->
+initialize_trie({_, _, {_, _, Node, CleanSession}}, Acc) when
+    Node =:= node(), CleanSession == true
+->
+    Acc;
+initialize_trie({MP, Topic, {SubscriberId, SubInfo, Node, _CleanSession}}, Acc) when
+    Node =:= node()
+->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
     add_subscriber(MP, Topic, SubscriberId, SubInfo),
     Acc;
-initialize_trie({MP, Topic, {_SubscriberId, _SubInfo, Node}}, Acc) ->
+initialize_trie({MP, Topic, {_SubscriberId, _SubInfo, Node, _CleanSession}}, Acc) ->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
     add_remote_subscriber(MP, Topic, Node),
     Acc.

--- a/apps/vmq_server/src/vmq_subscriber.erl
+++ b/apps/vmq_server/src/vmq_subscriber.erl
@@ -216,7 +216,7 @@ get_node_subs(Node, Subs) ->
 fold(Fun, Acc, Subs) ->
     lists:foldl(
         fun
-            ({Node, _, NSubs}, AccAcc) ->
+            ({Node, _CleanSession, NSubs}, AccAcc) ->
                 lists:foldl(
                     fun({Topic, SubInfo}, AccAccAcc) ->
                         Fun({Topic, SubInfo, Node}, AccAccAcc)


### PR DESCRIPTION
## Proposed Changes

- fold_subscriptions passes CleanSession into trie initialization callback
- vmq_reg_trie initialize_trie skips local clean-session subs (plain and shared topics) at boot
- Boot log reports local and remote subscription counts

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)